### PR TITLE
Add root-level entry point for API server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+"""Command-line entry point for running the FastAPI application."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import uvicorn
+
+
+def _add_src_to_path() -> None:
+    """Ensure the ``src`` directory is available on ``sys.path``."""
+
+    project_root = Path(__file__).resolve().parent
+    src_dir = project_root / "src"
+    src_dir_str = str(src_dir)
+    if src_dir_str not in sys.path:
+        sys.path.insert(0, src_dir_str)
+
+
+def main() -> None:
+    """Run the API server using Uvicorn."""
+
+    _add_src_to_path()
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8765, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/__main__.py
+++ b/src/app/__main__.py
@@ -1,12 +1,26 @@
 """Command-line entry point for running the Document Processor API server."""
 from __future__ import annotations
 
-import uvicorn
+import sys
+from pathlib import Path
+
+
+def _add_project_root_to_path() -> None:
+    """Make sure the project root is present on ``sys.path``."""
+
+    project_root = Path(__file__).resolve().parents[2]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
 
 
 def main() -> None:
-    """Start a Uvicorn server serving the FastAPI application."""
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8765, reload=False)
+    """Delegate to the root-level ``main`` module to start the server."""
+
+    _add_project_root_to_path()
+    from main import main as run_main
+
+    run_main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a root-level `main.py` so the application can be started from the project root
- ensure both entry points extend `sys.path` before importing the FastAPI app

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18b31a1b88333848f22a5403bb7cf