### PR TITLE
Improve classification JSON payload structure

### DIFF
--- a/src/app/domain/services/classification_extractor.py
+++ b/src/app/domain/services/classification_extractor.py
@@ -20,6 +20,39 @@ _STAT_KEYS: List[str] = [
     "sanction_points",
 ]
 
+_COLUMN_STRUCTURE: List[dict] = [
+    {"key": "team", "label": "Equipos"},
+    {"key": "points", "label": "Puntos"},
+    {
+        "key": "matches",
+        "label": "Partidos",
+        "children": [
+            {"key": "played", "label": "J."},
+            {"key": "wins", "label": "G."},
+            {"key": "draws", "label": "E."},
+            {"key": "losses", "label": "P."},
+        ],
+    },
+    {
+        "key": "goals",
+        "label": "Goles",
+        "children": [
+            {"key": "for", "label": "F."},
+            {"key": "against", "label": "C."},
+        ],
+    },
+    {
+        "key": "recent_form",
+        "label": "Últimos",
+        "children": [{"key": "points", "label": "Puntos"}],
+    },
+    {
+        "key": "sanction",
+        "label": "Sanción",
+        "children": [{"key": "points", "label": "Puntos"}],
+    },
+]
+
 _ROW_INDEX_PATTERN = re.compile(r"^\d+")
 _ROW_HAS_LETTER_PATTERN = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]")
 _ROW_PATTERN = re.compile(r"^(?P<position>\d+)\s*(?P<body>.+)$")
@@ -41,7 +74,19 @@ class ClassificationRow:
         return {
             "position": self.position,
             "team": self.team,
-            "stats": {key: value for key, value in self.stats.items()},
+            "points": self.stats.get("points"),
+            "matches": {
+                "played": self.stats.get("played"),
+                "wins": self.stats.get("wins"),
+                "draws": self.stats.get("draws"),
+                "losses": self.stats.get("losses"),
+            },
+            "goals": {
+                "for": self.stats.get("goals_for"),
+                "against": self.stats.get("goals_against"),
+            },
+            "recent_form": {"points": self.stats.get("last_points")},
+            "sanction": {"points": self.stats.get("sanction_points")},
             "raw": self.raw,
         }
 
@@ -57,8 +102,11 @@ class ClassificationTable:
         """Return a JSON-serializable representation of the classification table."""
 
         return {
-            "headers": list(self.headers),
-            "rows": [row.to_dict() for row in self.rows],
+            "metadata": {
+                "headers": list(self.headers),
+                "columns": _COLUMN_STRUCTURE,
+            },
+            "teams": [row.to_dict() for row in self.rows],
         }
 
 

--- a/tests/test_classification_extractor.py
+++ b/tests/test_classification_extractor.py
@@ -43,3 +43,18 @@ def test_merges_multi_line_rows_before_parsing() -> None:
     assert table.rows[0].stats["goals_against"] == 0
     assert table.rows[1].team == "CELTIC C.F."
     assert table.rows[1].stats["played"] == 2
+
+
+def test_to_dict_exposes_frontend_friendly_payload() -> None:
+    document = build_document(
+        "Equipos Partidos GolesÚltimosSanción",
+        "PuntosJ.G.E.P.F.C. Puntos",
+        "1ALBIRROJA 0 0 0 0 0 0 0 0",
+    )
+
+    table = extract_classification(document)
+    payload = table.to_dict()
+
+    assert payload["metadata"]["columns"][0]["label"] == "Equipos"
+    assert payload["metadata"]["columns"][2]["children"][0]["key"] == "played"
+    assert payload["teams"][0]["matches"]["wins"] == 0


### PR DESCRIPTION
## Summary
- reshape the classification table payload to include column metadata and grouped statistics for each team
- extend the classification extractor tests to cover the new frontend-focused JSON format

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d193ea857883339e6d6c2ae6316996