### PR TITLE
Refactor classification models and improve app wiring

### DIFF
--- a/src/app/domain/models/classification.py
+++ b/src/app/domain/models/classification.py
@@ -1,0 +1,133 @@
+"""Domain models representing extracted classification tables."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+_COLUMN_STRUCTURE: List[dict[str, Any]] = [
+    {"key": "team", "label": "Equipos"},
+    {"key": "points", "label": "Puntos"},
+    {
+        "key": "matches",
+        "label": "Partidos",
+        "children": [
+            {"key": "played", "label": "J."},
+            {"key": "wins", "label": "G."},
+            {"key": "draws", "label": "E."},
+            {"key": "losses", "label": "P."},
+        ],
+    },
+    {
+        "key": "goals",
+        "label": "Goles",
+        "children": [
+            {"key": "for", "label": "F."},
+            {"key": "against", "label": "C."},
+        ],
+    },
+    {
+        "key": "recent_form",
+        "label": "Últimos",
+        "children": [{"key": "points", "label": "Puntos"}],
+    },
+    {
+        "key": "sanction",
+        "label": "Sanción",
+        "children": [{"key": "points", "label": "Puntos"}],
+    },
+]
+
+
+@dataclass(frozen=True)
+class ClassificationRow:
+    """Represents a single team entry within the classification table."""
+
+    position: int
+    team: str
+    stats: dict[str, int | None] = field(default_factory=dict)
+    raw: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the classification row."""
+
+        return {
+            "position": self.position,
+            "team": self.team,
+            "points": self.stats.get("points"),
+            "matches": {
+                "played": self.stats.get("played"),
+                "wins": self.stats.get("wins"),
+                "draws": self.stats.get("draws"),
+                "losses": self.stats.get("losses"),
+            },
+            "goals": {
+                "for": self.stats.get("goals_for"),
+                "against": self.stats.get("goals_against"),
+            },
+            "recent_form": {"points": self.stats.get("last_points")},
+            "sanction": {"points": self.stats.get("sanction_points")},
+            "raw": self.raw,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ClassificationRow":
+        """Create a classification row from its serialized representation."""
+
+        matches = data.get("matches", {})
+        goals = data.get("goals", {})
+        recent_form = data.get("recent_form", {})
+        sanction = data.get("sanction", {})
+
+        stats = {
+            "points": data.get("points"),
+            "played": matches.get("played"),
+            "wins": matches.get("wins"),
+            "draws": matches.get("draws"),
+            "losses": matches.get("losses"),
+            "goals_for": goals.get("for"),
+            "goals_against": goals.get("against"),
+            "last_points": recent_form.get("points"),
+            "sanction_points": sanction.get("points"),
+        }
+
+        return cls(
+            position=int(data["position"]),
+            team=str(data["team"]),
+            stats=stats,
+            raw=str(data.get("raw", "")),
+        )
+
+
+@dataclass(frozen=True)
+class ClassificationTable:
+    """Represents the extracted classification section of a PDF document."""
+
+    headers: List[str] = field(default_factory=list)
+    rows: List[ClassificationRow] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the classification table."""
+
+        return {
+            "metadata": {
+                "headers": list(self.headers),
+                "columns": _COLUMN_STRUCTURE,
+            },
+            "teams": [row.to_dict() for row in self.rows],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ClassificationTable":
+        """Create a classification table from its serialized representation."""
+
+        metadata = data.get("metadata", {})
+        headers = [str(header) for header in metadata.get("headers", [])]
+        rows = [ClassificationRow.from_dict(item) for item in data.get("teams", [])]
+        return cls(headers=headers, rows=rows)
+
+
+__all__ = [
+    "ClassificationRow",
+    "ClassificationTable",
+]
+

--- a/src/app/domain/repositories/classification_repository.py
+++ b/src/app/domain/repositories/classification_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from app.domain.services.classification_extractor import ClassificationTable
+from app.domain.models.classification import ClassificationTable
 
 
 class ClassificationRepository(Protocol):

--- a/src/app/domain/services/classification_extractor.py
+++ b/src/app/domain/services/classification_extractor.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
-from typing import Any, List
+from typing import List
 
+from app.domain.models.classification import ClassificationRow, ClassificationTable
 from app.domain.models.document import ParsedDocument
 
 
@@ -20,39 +20,6 @@ _STAT_KEYS: List[str] = [
     "sanction_points",
 ]
 
-
-_COLUMN_STRUCTURE: List[dict] = [
-    {"key": "team", "label": "Equipos"},
-    {"key": "points", "label": "Puntos"},
-    {
-        "key": "matches",
-        "label": "Partidos",
-        "children": [
-            {"key": "played", "label": "J."},
-            {"key": "wins", "label": "G."},
-            {"key": "draws", "label": "E."},
-            {"key": "losses", "label": "P."},
-        ],
-    },
-    {
-        "key": "goals",
-        "label": "Goles",
-        "children": [
-            {"key": "for", "label": "F."},
-            {"key": "against", "label": "C."},
-        ],
-    },
-    {
-        "key": "recent_form",
-        "label": "Últimos",
-        "children": [{"key": "points", "label": "Puntos"}],
-    },
-    {
-        "key": "sanction",
-        "label": "Sanción",
-        "children": [{"key": "points", "label": "Puntos"}],
-    },
-]
 
 _ROW_INDEX_PATTERN = re.compile(r"^\d+")
 _ROW_HAS_LETTER_PATTERN = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]")
@@ -70,94 +37,6 @@ _STAT_LENGTH_RULES: List[tuple[int, ...]] = [
     (2, 1),  # recent form points
     (2, 1),  # sanction points
 ]
-
-
-@dataclass(frozen=True)
-class ClassificationRow:
-    """Represents a single team entry within the classification table."""
-
-    position: int
-    team: str
-    stats: dict[str, int | None] = field(default_factory=dict)
-    raw: str = ""
-
-    def to_dict(self) -> dict:
-        """Return a JSON-serializable representation of the classification row."""
-
-        return {
-            "position": self.position,
-            "team": self.team,
-            "points": self.stats.get("points"),
-            "matches": {
-                "played": self.stats.get("played"),
-                "wins": self.stats.get("wins"),
-                "draws": self.stats.get("draws"),
-                "losses": self.stats.get("losses"),
-            },
-            "goals": {
-                "for": self.stats.get("goals_for"),
-                "against": self.stats.get("goals_against"),
-            },
-            "recent_form": {"points": self.stats.get("last_points")},
-            "sanction": {"points": self.stats.get("sanction_points")},
-            "raw": self.raw,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ClassificationRow":
-        """Create a classification row from its serialized representation."""
-
-        matches = data.get("matches", {})
-        goals = data.get("goals", {})
-        recent_form = data.get("recent_form", {})
-        sanction = data.get("sanction", {})
-
-        stats = {
-            "points": data.get("points"),
-            "played": matches.get("played"),
-            "wins": matches.get("wins"),
-            "draws": matches.get("draws"),
-            "losses": matches.get("losses"),
-            "goals_for": goals.get("for"),
-            "goals_against": goals.get("against"),
-            "last_points": recent_form.get("points"),
-            "sanction_points": sanction.get("points"),
-        }
-
-        return cls(
-            position=int(data["position"]),
-            team=str(data["team"]),
-            stats=stats,
-            raw=str(data.get("raw", "")),
-        )
-
-
-@dataclass(frozen=True)
-class ClassificationTable:
-    """Represents the extracted classification section of a PDF document."""
-
-    headers: List[str] = field(default_factory=list)
-    rows: List[ClassificationRow] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        """Return a JSON-serializable representation of the classification table."""
-
-        return {
-            "metadata": {
-                "headers": list(self.headers),
-                "columns": _COLUMN_STRUCTURE,
-            },
-            "teams": [row.to_dict() for row in self.rows],
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ClassificationTable":
-        """Create a classification table from its serialized representation."""
-
-        metadata = data.get("metadata", {})
-        headers = [str(header) for header in metadata.get("headers", [])]
-        rows = [ClassificationRow.from_dict(item) for item in data.get("teams", [])]
-        return cls(headers=headers, rows=rows)
 
 
 def extract_classification(document: ParsedDocument) -> ClassificationTable:

--- a/src/app/infrastructure/repositories/json_classification_repository.py
+++ b/src/app/infrastructure/repositories/json_classification_repository.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from app.domain.models.classification import ClassificationTable
 from app.domain.repositories.classification_repository import ClassificationRepository
-from app.domain.services.classification_extractor import ClassificationTable
 
 
 class JsonClassificationRepository(ClassificationRepository):

--- a/tests/test_classification_extractor.py
+++ b/tests/test_classification_extractor.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
+from app.domain.models.classification import ClassificationRow, ClassificationTable
 from app.domain.models.document import DocumentPage, ParsedDocument
-from app.domain.services.classification_extractor import (
-    ClassificationRow,
-    ClassificationTable,
-    extract_classification,
-)
+from app.domain.services.classification_extractor import extract_classification
 
 
 def build_document(*lines: str) -> ParsedDocument:

--- a/tests/test_json_classification_repository.py
+++ b/tests/test_json_classification_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.domain.services.classification_extractor import ClassificationRow, ClassificationTable
+from app.domain.models.classification import ClassificationRow, ClassificationTable
 from app.infrastructure.repositories.json_classification_repository import (
     JsonClassificationRepository,
 )


### PR DESCRIPTION
## Summary
- extract the classification table dataclasses into dedicated domain models and update services and repositories to consume them
- harden the JSON document repository against malformed page payloads when loading stored schedules
- expose a `create_app` factory to configure FastAPI dependencies while keeping the default wiring intact

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1aed245a083338c7f6768b516fe03