### PR TITLE
Refactor classification workflow and harden API

### DIFF
--- a/src/app/application/process_classification.py
+++ b/src/app/application/process_classification.py
@@ -1,0 +1,55 @@
+"""Use cases for processing and retrieving classification tables."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.application.process_document import DocumentParser
+from app.domain.models.classification import ClassificationTable
+from app.domain.models.document import ParsedDocument
+from app.domain.repositories.classification_repository import ClassificationRepository
+
+
+class ClassificationExtractor(Protocol):
+    """Represent a service able to extract classification data from documents."""
+
+    def extract(self, document: ParsedDocument) -> ClassificationTable:
+        """Return the structured classification table present in ``document``."""
+
+
+class ProcessClassificationUseCase:
+    """Handle classification ingestion from raw PDF bytes."""
+
+    def __init__(
+        self,
+        parser: DocumentParser,
+        extractor: ClassificationExtractor,
+        repository: ClassificationRepository,
+    ) -> None:
+        """Initialize the use case with its required collaborators."""
+
+        self._parser = parser
+        self._extractor = extractor
+        self._repository = repository
+
+    def execute(self, document_bytes: bytes) -> ClassificationTable:
+        """Parse, extract and persist the classification table contained in a PDF."""
+
+        parsed_document = self._parser.parse(document_bytes)
+        classification_table = self._extractor.extract(parsed_document)
+        self._repository.save(classification_table)
+        return classification_table
+
+
+class RetrieveClassificationUseCase:
+    """Retrieve the last processed classification table."""
+
+    def __init__(self, repository: ClassificationRepository) -> None:
+        """Initialize the use case with the repository dependency."""
+
+        self._repository = repository
+
+    def execute(self) -> ClassificationTable | None:
+        """Return the stored classification table when available."""
+
+        return self._repository.load()
+

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Tuple
 
 
 @dataclass(frozen=True)
@@ -12,18 +13,37 @@ class Settings:
     data_dir: Path = Path("data")
     classification_filename: str = "classification.json"
     schedule_filename: str = "schedule.json"
+    app_version: str = "0.1.0"
+    api_version: str = "v1"
+    allowed_origins: Tuple[str, ...] = ("*",)
+    max_upload_size_mb: int = 10
 
     @property
     def classification_path(self) -> Path:
         """Return the full path for storing classification data."""
+
         return self.data_dir / self.classification_filename
 
     @property
     def schedule_path(self) -> Path:
         """Return the full path for storing schedule data."""
+
         return self.data_dir / self.schedule_filename
+
+    @property
+    def api_prefix(self) -> str:
+        """Return the URL prefix used for versioned API routes."""
+
+        return f"/api/{self.api_version}"
+
+    @property
+    def max_upload_size_bytes(self) -> int:
+        """Return the maximum allowed upload size in bytes."""
+
+        return self.max_upload_size_mb * 1024 * 1024
 
 
 def get_settings() -> Settings:
     """Provide the default application settings."""
+
     return Settings()

--- a/src/app/domain/repositories/document_repository.py
+++ b/src/app/domain/repositories/document_repository.py
@@ -1,19 +1,16 @@
 """Repository interfaces for storing parsed documents."""
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Protocol
 
 from app.domain.models.document import ParsedDocument
 
 
-class DocumentRepository(ABC):
-    """Defines the behavior of a repository that stores parsed documents."""
+class DocumentRepository(Protocol):
+    """Persist and retrieve parsed documents."""
 
-    @abstractmethod
     def save(self, document: ParsedDocument) -> None:
         """Persist the provided parsed document."""
 
-    @abstractmethod
     def load(self) -> Optional[ParsedDocument]:
         """Retrieve the stored parsed document if available."""

--- a/src/app/domain/services/classification_decoders.py
+++ b/src/app/domain/services/classification_decoders.py
@@ -1,0 +1,266 @@
+"""Supporting components for decoding classification table rows."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from app.domain.models.classification import ClassificationRow
+
+
+_ROW_INDEX_PATTERN = re.compile(r"^\d+")
+_ROW_HAS_LETTER_PATTERN = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]")
+_ROW_PATTERN = re.compile(r"^(?P<position>\d+)\s*(?P<body>.+)$")
+_TRAILING_NUMBERS_PATTERN = re.compile(r"(\d[\d\s]*)$")
+
+
+@dataclass(frozen=True)
+class StatisticsDecoderConfig:
+    """Configuration values governing statistics decoding."""
+
+    stat_keys: Sequence[str]
+    length_rules: Sequence[tuple[int, ...]]
+
+
+class StatisticsDecoder:
+    """Decode trailing numeric sections into structured statistics."""
+
+    def __init__(self, config: StatisticsDecoderConfig) -> None:
+        """Initialize the decoder with its configuration."""
+
+        self._stat_keys = list(config.stat_keys)
+        self._length_rules = list(config.length_rules)
+
+    def decode(self, stats_section: str) -> List[int]:
+        """Return statistics extracted from the provided section."""
+
+        expected_values = len(self._stat_keys)
+        tokens = re.findall(r"\d+", stats_section)
+
+        values = self._decode_from_tokens(tokens, expected_values)
+        if values is None:
+            values = self._normalize_values([], expected_values, stats_section)
+
+        return self._pad_missing_values(values, expected_values)
+
+    def _decode_from_tokens(
+        self, tokens: Iterable[str], expected_values: int
+    ) -> List[int] | None:
+        token_list = list(tokens)
+        if not token_list:
+            return None
+
+        numeric_tokens = [int(token) for token in token_list]
+
+        if len(numeric_tokens) >= expected_values:
+            candidate = numeric_tokens[:expected_values]
+            if self._stats_are_consistent(candidate):
+                return candidate
+
+        digits_sequence = "".join(token_list)
+        segmented_values = self._segment_digits_sequence(digits_sequence, expected_values)
+        if segmented_values is not None:
+            return segmented_values
+
+        if len(numeric_tokens) >= expected_values:
+            return numeric_tokens[:expected_values]
+
+        values: List[int] = []
+        for token in numeric_tokens:
+            if len(values) >= expected_values:
+                break
+            values.append(token)
+
+        if len(token_list) == 1 and len(digits_sequence := "".join(token_list)) > 2 and len(values) < expected_values:
+            values = []
+            return self._normalize_values(values, expected_values, digits_sequence)
+
+        normalized = self._normalize_values(values, expected_values, digits_sequence)
+        return normalized if normalized else None
+
+    def _normalize_values(
+        self, values: List[int], expected_values: int, stats_section: str
+    ) -> List[int]:
+        if len(values) >= expected_values:
+            return values[:expected_values]
+
+        digits = re.findall(r"\d", stats_section)
+        if not digits:
+            default_value = values[-1] if values else 0
+            while len(values) < expected_values:
+                values.append(default_value)
+            return values
+
+        default_value = 0 if all(digit == "0" for digit in digits) else (values[-1] if values else 0)
+        while len(values) < expected_values:
+            values.append(default_value)
+        return values
+
+    def _pad_missing_values(self, values: List[int], expected_values: int) -> List[int]:
+        if len(values) >= expected_values:
+            return values[:expected_values]
+
+        padded_values = list(values)
+        default_value = padded_values[-1] if padded_values else 0
+
+        while len(padded_values) < expected_values:
+            padded_values.append(default_value)
+
+        return padded_values
+
+    def _segment_digits_sequence(
+        self, digits: str, expected_values: int
+    ) -> List[int] | None:
+        if not digits:
+            return None
+
+        values: List[int] = []
+        solution: List[int] | None = None
+
+        def backtrack(stat_index: int, position: int) -> bool:
+            nonlocal solution
+
+            if stat_index == expected_values:
+                if position == len(digits) and self._stats_are_consistent(values):
+                    solution = list(values)
+                    return True
+                return False
+
+            remaining_digits = len(digits) - position
+            remaining_stats = expected_values - stat_index
+            if remaining_digits < remaining_stats:
+                return False
+
+            for length in self._length_rules[stat_index]:
+                if position + length > len(digits):
+                    continue
+
+                value = int(digits[position : position + length])
+                values.append(value)
+
+                if self._partial_stats_are_valid(values):
+                    if backtrack(stat_index + 1, position + length):
+                        return True
+
+                values.pop()
+
+            return False
+
+        backtrack(0, 0)
+        return solution
+
+    def _partial_stats_are_valid(self, values: Sequence[int]) -> bool:
+        if len(values) <= 1:
+            return True
+
+        played = values[1]
+        if len(values) >= 3 and values[2] > played:
+            return False
+        if len(values) >= 4 and values[2] + values[3] > played:
+            return False
+        if len(values) >= 5 and values[2] + values[3] + values[4] > played:
+            return False
+
+        return True
+
+    def _stats_are_consistent(self, values: Sequence[int]) -> bool:
+        if len(values) < len(self._stat_keys):
+            return False
+
+        points, played, wins, draws, losses, *_rest, last_points, sanction = values
+
+        if played != wins + draws + losses:
+            return False
+
+        computed_points = wins * 3 + draws - sanction
+        if computed_points < 0:
+            return False
+
+        if computed_points != points:
+            return False
+
+        if last_points < 0 or sanction < 0:
+            return False
+
+        return True
+
+
+class ClassificationRowDecoder:
+    """Translate textual row representations into domain objects."""
+
+    def __init__(
+        self,
+        stat_keys: Sequence[str],
+        statistics_decoder: StatisticsDecoder,
+    ) -> None:
+        """Store dependencies required to decode a classification row."""
+
+        self._stat_keys = list(stat_keys)
+        self._statistics_decoder = statistics_decoder
+
+    def decode(self, line: str) -> ClassificationRow | None:
+        """Return the row encoded in ``line`` or ``None`` when parsing fails."""
+
+        match = _ROW_PATTERN.match(line)
+        if match is None:
+            return None
+
+        position = int(match.group("position"))
+        body = match.group("body").strip()
+        if not body:
+            return None
+
+        stats_section_match = _TRAILING_NUMBERS_PATTERN.search(body)
+        if stats_section_match is None:
+            team = body
+            stats_section = ""
+        else:
+            stats_section = stats_section_match.group(1)
+            team = body[: stats_section_match.start()].strip()
+
+        if not team:
+            return None
+
+        stats_values = self._statistics_decoder.decode(stats_section)
+        stats = {
+            key: stats_values[index] if index < len(stats_values) else None
+            for index, key in enumerate(self._stat_keys)
+        }
+
+        return ClassificationRow(position=position, team=team, stats=stats, raw=line)
+
+
+class RowAssembler:
+    """Compose complete rows from potentially fragmented line sequences."""
+
+    def merge(self, lines: Sequence[str]) -> List[str]:
+        """Return a list of assembled row strings."""
+
+        merged_rows: List[str] = []
+        current_row: str | None = None
+
+        for line in lines:
+            if self._is_row_start(line):
+                if current_row:
+                    merged_rows.append(current_row.strip())
+                current_row = line
+            elif current_row:
+                current_row = f"{current_row} {line}".strip()
+
+        if current_row:
+            merged_rows.append(current_row.strip())
+
+        return merged_rows
+
+    @staticmethod
+    def _is_row_start(line: str) -> bool:
+        return bool(_ROW_INDEX_PATTERN.match(line) and _ROW_HAS_LETTER_PATTERN.search(line))
+
+
+__all__ = [
+    "ClassificationRowDecoder",
+    "RowAssembler",
+    "StatisticsDecoder",
+    "StatisticsDecoderConfig",
+]
+

--- a/src/app/domain/services/classification_extractor.py
+++ b/src/app/domain/services/classification_extractor.py
@@ -2,13 +2,19 @@
 from __future__ import annotations
 
 import re
-from typing import List
+from typing import List, Sequence
 
-from app.domain.models.classification import ClassificationRow, ClassificationTable
+from app.domain.models.classification import ClassificationTable
 from app.domain.models.document import ParsedDocument
+from app.domain.services.classification_decoders import (
+    ClassificationRowDecoder,
+    RowAssembler,
+    StatisticsDecoder,
+    StatisticsDecoderConfig,
+)
 
 
-_STAT_KEYS: List[str] = [
+_STAT_KEYS: Sequence[str] = (
     "points",
     "played",
     "wins",
@@ -18,15 +24,10 @@ _STAT_KEYS: List[str] = [
     "goals_against",
     "last_points",
     "sanction_points",
-]
+)
 
 
-_ROW_INDEX_PATTERN = re.compile(r"^\d+")
-_ROW_HAS_LETTER_PATTERN = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]")
-_ROW_PATTERN = re.compile(r"^(?P<position>\d+)\s*(?P<body>.+)$")
-_TRAILING_NUMBERS_PATTERN = re.compile(r"(\d[\d\s]*)$")
-
-_STAT_LENGTH_RULES: List[tuple[int, ...]] = [
+_STAT_LENGTH_RULES: Sequence[tuple[int, ...]] = (
     (3, 2, 1),  # points can reach triple digits with long seasons
     (2, 1),  # played
     (2, 1),  # wins
@@ -36,273 +37,80 @@ _STAT_LENGTH_RULES: List[tuple[int, ...]] = [
     (2, 1),  # goals against
     (2, 1),  # recent form points
     (2, 1),  # sanction points
-]
+)
+
+
+class ClassificationExtractorService:
+    """Coordinate the extraction of classification data from parsed documents."""
+
+    def __init__(
+        self,
+        row_decoder: ClassificationRowDecoder | None = None,
+        row_assembler: RowAssembler | None = None,
+    ) -> None:
+        """Configure the extractor with optional custom collaborators."""
+
+        if row_decoder is None:
+            statistics_decoder = StatisticsDecoder(
+                StatisticsDecoderConfig(stat_keys=_STAT_KEYS, length_rules=_STAT_LENGTH_RULES)
+            )
+            self._row_decoder = ClassificationRowDecoder(_STAT_KEYS, statistics_decoder)
+        else:
+            self._row_decoder = row_decoder
+        self._row_assembler = row_assembler or RowAssembler()
+
+    def extract(self, document: ParsedDocument) -> ClassificationTable:
+        """Return the classification table contained in ``document``."""
+
+        lines: List[str] = [line for page in document.pages for line in page.content]
+        normalized_lines = [re.sub(r"\s+", " ", line).strip() for line in lines if line.strip()]
+
+        start_index = self._find_section_start(normalized_lines)
+        end_index = self._find_section_end(normalized_lines, start_index)
+
+        section_lines = normalized_lines[start_index:end_index]
+        if not section_lines:
+            return ClassificationTable()
+
+        headers = section_lines[:2] if len(section_lines) >= 2 else section_lines
+        row_lines = self._row_assembler.merge(section_lines[len(headers) :])
+
+        rows = [
+            parsed_row
+            for line in row_lines
+            if (parsed_row := self._row_decoder.decode(line)) is not None
+        ]
+
+        return ClassificationTable(headers=headers, rows=rows)
+
+    @staticmethod
+    def _find_section_start(lines: Sequence[str]) -> int:
+        """Return the index of the line that marks the classification header."""
+
+        for index, line in enumerate(lines):
+            if "equipos" in line.casefold():
+                return index
+        raise ValueError("The classification header line was not found in the document.")
+
+    @staticmethod
+    def _find_section_end(lines: Sequence[str], start_index: int) -> int:
+        """Return the index of the line where the classification section ends."""
+
+        for index in range(start_index, len(lines)):
+            lowered_line = lines[index].casefold()
+            if "resultado provisional" in lowered_line or lowered_line.startswith("(*)"):
+                return index
+        return len(lines)
 
 
 def extract_classification(document: ParsedDocument) -> ClassificationTable:
-    """Extract the classification table from the parsed document content."""
+    """Convenience wrapper that extracts the classification table from ``document``."""
 
-    lines: List[str] = [line for page in document.pages for line in page.content]
-    normalized_lines = [re.sub(r"\s+", " ", line).strip() for line in lines if line.strip()]
+    extractor = ClassificationExtractorService()
+    return extractor.extract(document)
 
-    start_index = _find_section_start(normalized_lines)
-    end_index = _find_section_end(normalized_lines, start_index)
 
-    section_lines = normalized_lines[start_index:end_index]
-    if not section_lines:
-        return ClassificationTable()
-
-    headers = section_lines[:2] if len(section_lines) >= 2 else section_lines
-    row_lines = _merge_row_lines(section_lines[len(headers) :])
-
-    rows: List[ClassificationRow] = []
-    for line in row_lines:
-        parsed_row = _parse_row(line)
-        if parsed_row is not None:
-            rows.append(parsed_row)
-
-    return ClassificationTable(headers=headers, rows=rows)
-
-
-def _find_section_start(lines: List[str]) -> int:
-    """Return the index of the line that marks the classification header."""
-
-    for index, line in enumerate(lines):
-        if "equipos" in line.casefold():
-            return index
-    raise ValueError("The classification header line was not found in the document.")
-
-
-def _find_section_end(lines: List[str], start_index: int) -> int:
-    """Return the index of the line where the classification section ends."""
-
-    for index in range(start_index, len(lines)):
-        lowered_line = lines[index].casefold()
-        if "resultado provisional" in lowered_line or lowered_line.startswith("(*)"):
-            return index
-    return len(lines)
-
-
-def _parse_row(line: str) -> ClassificationRow | None:
-    """Parse a row of the classification table into a structured entry."""
-
-    match = _ROW_PATTERN.match(line)
-    if match is None:
-        return None
-
-    position = int(match.group("position"))
-    body = match.group("body").strip()
-    if not body:
-        return None
-
-    stats_section_match = _TRAILING_NUMBERS_PATTERN.search(body)
-    if stats_section_match is None:
-        team = body
-        stats_section = ""
-    else:
-        stats_section = stats_section_match.group(1)
-        team = body[: stats_section_match.start()].strip()
-
-    if not team:
-        return None
-
-    stats_values = _extract_stat_values(stats_section)
-    stats = {
-        key: stats_values[index] if index < len(stats_values) else None
-        for index, key in enumerate(_STAT_KEYS)
-    }
-
-    return ClassificationRow(position=position, team=team, stats=stats, raw=line)
-
-
-def _merge_row_lines(lines: List[str]) -> List[str]:
-    """Merge row fragments that span multiple lines into single entries."""
-
-    merged_rows: List[str] = []
-    current_row: str | None = None
-
-    for line in lines:
-        if _is_row_start(line):
-            if current_row:
-                merged_rows.append(current_row.strip())
-            current_row = line
-        elif current_row:
-            current_row = f"{current_row} {line}".strip()
-
-    if current_row:
-        merged_rows.append(current_row.strip())
-
-    return merged_rows
-
-
-def _is_row_start(line: str) -> bool:
-    """Return ``True`` when the provided line starts a new classification row."""
-
-    return bool(_ROW_INDEX_PATTERN.match(line) and _ROW_HAS_LETTER_PATTERN.search(line))
-
-
-def _extract_stat_values(stats_section: str) -> List[int]:
-    """Return numeric statistics extracted from the row tail section."""
-
-    expected_values = len(_STAT_KEYS)
-    tokens = re.findall(r"\d+", stats_section)
-
-    values = _decode_stats_from_tokens(tokens, expected_values)
-    if values is None:
-        values = _normalize_stat_values([], expected_values, stats_section)
-
-    return _pad_missing_statistics(values, expected_values)
-
-
-def _decode_stats_from_tokens(tokens: List[str], expected_values: int) -> List[int] | None:
-    """Return statistics resolved from digit tokens when possible."""
-
-    if not tokens:
-        return None
-
-    numeric_tokens = [int(token) for token in tokens]
-    if len(numeric_tokens) >= expected_values:
-        candidate = numeric_tokens[:expected_values]
-        if _stats_are_consistent(candidate):
-            return candidate
-
-    digits_sequence = "".join(tokens)
-    segmented_values = _segment_digits_sequence(digits_sequence, expected_values)
-    if segmented_values is not None:
-        return segmented_values
-
-    if len(numeric_tokens) >= expected_values:
-        return numeric_tokens[:expected_values]
-
-    values: List[int] = []
-    for token in tokens:
-        if len(values) >= expected_values:
-            break
-        values.append(int(token))
-
-    if len(tokens) == 1 and len(tokens[0]) > 2 and len(values) < expected_values:
-        values = []
-
-    normalized = _normalize_stat_values(values, expected_values, digits_sequence)
-    return normalized if normalized else None
-
-
-def _normalize_stat_values(
-    values: List[int], expected_values: int, stats_section: str
-) -> List[int]:
-    """Fill missing statistic slots with sensible defaults when data is partial."""
-
-    if len(values) >= expected_values:
-        return values[:expected_values]
-
-    digits = re.findall(r"\d", stats_section)
-    if not digits:
-        default_value = values[-1] if values else 0
-        while len(values) < expected_values:
-            values.append(default_value)
-        return values
-
-    default_value = 0 if all(digit == "0" for digit in digits) else (values[-1] if values else 0)
-
-    while len(values) < expected_values:
-        values.append(default_value)
-
-    return values
-
-
-def _pad_missing_statistics(values: List[int], expected_values: int) -> List[int]:
-    """Ensure the returned statistics list always covers the expected columns."""
-
-    if len(values) >= expected_values:
-        return values[:expected_values]
-
-    padded_values = list(values)
-    default_value = padded_values[-1] if padded_values else 0
-
-    while len(padded_values) < expected_values:
-        padded_values.append(default_value)
-
-    return padded_values
-
-
-def _segment_digits_sequence(digits: str, expected_values: int) -> List[int] | None:
-    """Return statistics obtained by segmenting a raw digit sequence."""
-
-    if not digits:
-        return None
-
-    values: List[int] = []
-    solution: List[int] | None = None
-
-    def backtrack(stat_index: int, position: int) -> bool:
-        nonlocal solution
-
-        if stat_index == expected_values:
-            if position == len(digits) and _stats_are_consistent(values):
-                solution = list(values)
-                return True
-            return False
-
-        remaining_digits = len(digits) - position
-        remaining_stats = expected_values - stat_index
-        if remaining_digits < remaining_stats:
-            return False
-
-        for length in _STAT_LENGTH_RULES[stat_index]:
-            if position + length > len(digits):
-                continue
-
-            value = int(digits[position : position + length])
-            values.append(value)
-
-            if _partial_stats_are_valid(values):
-                if backtrack(stat_index + 1, position + length):
-                    return True
-
-            values.pop()
-
-        return False
-
-    backtrack(0, 0)
-    return solution
-
-
-def _partial_stats_are_valid(values: List[int]) -> bool:
-    """Return ``True`` while the partial segmentation remains coherent."""
-
-    if len(values) <= 1:
-        return True
-
-    played = values[1]
-    if len(values) >= 3 and values[2] > played:
-        return False
-    if len(values) >= 4 and values[2] + values[3] > played:
-        return False
-    if len(values) >= 5 and values[2] + values[3] + values[4] > played:
-        return False
-
-    return True
-
-
-def _stats_are_consistent(values: List[int]) -> bool:
-    """Return ``True`` when the provided statistics satisfy basic invariants."""
-
-    if len(values) < len(_STAT_KEYS):
-        return False
-
-    points, played, wins, draws, losses, *_rest, last_points, sanction = values
-
-    if played != wins + draws + losses:
-        return False
-
-    computed_points = wins * 3 + draws - sanction
-    if computed_points < 0:
-        return False
-
-    if computed_points != points:
-        return False
-
-    if last_points < 0 or sanction < 0:
-        return False
-
-    return True
+__all__ = [
+    "ClassificationExtractorService",
+    "extract_classification",
+]

--- a/src/app/infrastructure/parsers/pdf_document_parser.py
+++ b/src/app/infrastructure/parsers/pdf_document_parser.py
@@ -5,6 +5,7 @@ import io
 from typing import List
 
 from PyPDF2 import PdfReader
+from PyPDF2.errors import PdfReadError
 
 from app.domain.models.document import DocumentPage, ParsedDocument
 
@@ -14,10 +15,20 @@ class PdfDocumentParser:
 
     def parse(self, document_bytes: bytes) -> ParsedDocument:
         """Extract the textual content of each page from the provided PDF bytes."""
-        reader = PdfReader(io.BytesIO(document_bytes))
+
+        try:
+            reader = PdfReader(io.BytesIO(document_bytes))
+        except PdfReadError as error:
+            raise ValueError("The provided PDF file could not be read.") from error
+        except Exception as error:  # pragma: no cover - defensive fallback
+            raise ValueError("Unexpected error while reading the PDF file.") from error
+
         pages: List[DocumentPage] = []
         for index, page in enumerate(reader.pages, start=1):
-            text = page.extract_text() or ""
+            try:
+                text = page.extract_text() or ""
+            except PdfReadError as error:
+                raise ValueError("The PDF file contains unreadable pages.") from error
             lines = [line.strip() for line in text.splitlines() if line.strip()]
             pages.append(DocumentPage(number=index, content=lines))
         return ParsedDocument(pages=pages)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,8 +1,13 @@
 """Application entry point defining the HTTP API."""
 from __future__ import annotations
 
-from fastapi import FastAPI, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, FastAPI, File, HTTPException, UploadFile, status
+from fastapi.middleware.cors import CORSMiddleware
 
+from app.application.process_classification import (
+    ProcessClassificationUseCase,
+    RetrieveClassificationUseCase,
+)
 from app.application.process_document import (
     DocumentParser,
     ProcessDocumentUseCase,
@@ -11,7 +16,7 @@ from app.application.process_document import (
 from app.config.settings import get_settings
 from app.domain.repositories.classification_repository import ClassificationRepository
 from app.domain.repositories.document_repository import DocumentRepository
-from app.domain.services.classification_extractor import extract_classification
+from app.domain.services.classification_extractor import ClassificationExtractorService
 from app.infrastructure.parsers.pdf_document_parser import PdfDocumentParser
 from app.infrastructure.repositories.json_classification_repository import (
     JsonClassificationRepository,
@@ -33,32 +38,49 @@ def create_app(
         or JsonClassificationRepository(settings.classification_path)
     )
     schedule_repository = schedule_repo or JsonFileRepository(settings.schedule_path)
+
+    classification_extractor = ClassificationExtractorService()
+    classification_processor = ProcessClassificationUseCase(
+        pdf_parser,
+        classification_extractor,
+        classification_repository,
+    )
+    classification_retriever = RetrieveClassificationUseCase(classification_repository)
+
     schedule_processor = ProcessDocumentUseCase(pdf_parser, schedule_repository)
     schedule_retriever = RetrieveDocumentUseCase(schedule_repository)
 
-    app = FastAPI(title="Document Processor API", version="0.1.0")
+    app = FastAPI(title="Document Processor API", version=settings.app_version)
 
-    @app.post("/classification/pdf", status_code=status.HTTP_201_CREATED)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.allowed_origins),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    api_router = APIRouter(prefix=settings.api_prefix)
+
+    @api_router.post("/classification", status_code=status.HTTP_201_CREATED)
     async def upload_classification(file: UploadFile = File(...)) -> dict:
         """Parse and persist the uploaded classification PDF, returning its JSON form."""
 
-        pdf_bytes = await _read_pdf_bytes(file)
-        parsed_document = pdf_parser.parse(pdf_bytes)
+        pdf_bytes = await _read_pdf_bytes(file, settings.max_upload_size_bytes)
         try:
-            classification_table = extract_classification(parsed_document)
+            classification_table = classification_processor.execute(pdf_bytes)
         except ValueError as extraction_error:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=str(extraction_error),
             ) from extraction_error
-        classification_repository.save(classification_table)
         return classification_table.to_dict()
 
-    @app.get("/classification", status_code=status.HTTP_200_OK)
+    @api_router.get("/classification", status_code=status.HTTP_200_OK)
     async def get_classification() -> dict:
         """Retrieve the stored classification document as JSON."""
 
-        classification_table = classification_repository.load()
+        classification_table = classification_retriever.execute()
         if classification_table is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -66,15 +88,21 @@ def create_app(
             )
         return classification_table.to_dict()
 
-    @app.post("/schedule/pdf", status_code=status.HTTP_201_CREATED)
+    @api_router.post("/schedule", status_code=status.HTTP_201_CREATED)
     async def upload_schedule(file: UploadFile = File(...)) -> dict:
         """Parse and persist the uploaded schedule PDF, returning its JSON form."""
 
-        pdf_bytes = await _read_pdf_bytes(file)
-        parsed_document = schedule_processor.execute(pdf_bytes)
+        pdf_bytes = await _read_pdf_bytes(file, settings.max_upload_size_bytes)
+        try:
+            parsed_document = schedule_processor.execute(pdf_bytes)
+        except ValueError as processing_error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(processing_error),
+            ) from processing_error
         return parsed_document.to_dict()
 
-    @app.get("/schedule", status_code=status.HTTP_200_OK)
+    @api_router.get("/schedule", status_code=status.HTTP_200_OK)
     async def get_schedule() -> dict:
         """Retrieve the stored schedule document as JSON."""
 
@@ -86,23 +114,33 @@ def create_app(
             )
         return parsed_document.to_dict()
 
+    app.include_router(api_router)
     return app
 
 
 app = create_app()
 
 
-async def _read_pdf_bytes(uploaded_file: UploadFile) -> bytes:
-    """Ensure the provided file is a PDF and return its bytes."""
+async def _read_pdf_bytes(uploaded_file: UploadFile, max_size_bytes: int) -> bytes:
+    """Ensure the provided file is a PDF and return its bytes respecting size limits."""
+
     if uploaded_file.content_type not in {"application/pdf", "application/x-pdf"}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The uploaded file must be a PDF.",
         )
+
     file_bytes = await uploaded_file.read()
     if not file_bytes:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The PDF file is empty.",
         )
+
+    if len(file_bytes) > max_size_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="The PDF file exceeds the allowed size.",
+        )
+
     return file_bytes


### PR DESCRIPTION
## Summary
- add dedicated classification use cases and refactor the extractor into smaller decoding collaborators to reduce complexity
- version the HTTP API under /api/v1, reuse a unified PDF upload helper with size limits, and enable configurable CORS
- harden PDF parsing with graceful error handling and align repository abstractions on Protocols

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1b2fc320c8333a0904e2b15473949