### PR TITLE
Add Real Tajo calendar ingestion endpoints

### DIFF
--- a/src/app/application/process_real_tajo_calendar.py
+++ b/src/app/application/process_real_tajo_calendar.py
@@ -1,0 +1,45 @@
+"""Use cases for processing the Real Tajo calendar document."""
+from __future__ import annotations
+
+from app.application.process_document import DocumentParser
+from app.domain.models.real_tajo_calendar import RealTajoCalendar
+from app.domain.repositories.real_tajo_calendar_repository import RealTajoCalendarRepository
+from app.domain.services.real_tajo_calendar_extractor import RealTajoCalendarExtractorService
+
+
+class ProcessRealTajoCalendarUseCase:
+    """Handle ingestion of the Real Tajo calendar PDF."""
+
+    def __init__(
+        self,
+        parser: DocumentParser,
+        extractor: RealTajoCalendarExtractorService,
+        repository: RealTajoCalendarRepository,
+    ) -> None:
+        """Initialize the use case with its dependencies."""
+
+        self._parser = parser
+        self._extractor = extractor
+        self._repository = repository
+
+    def execute(self, document_bytes: bytes) -> RealTajoCalendar:
+        """Parse, extract and persist the Real Tajo calendar aggregate."""
+
+        parsed_document = self._parser.parse(document_bytes)
+        calendar = self._extractor.extract(parsed_document)
+        self._repository.save(calendar)
+        return calendar
+
+
+class RetrieveRealTajoCalendarUseCase:
+    """Retrieve the stored Real Tajo calendar aggregate if available."""
+
+    def __init__(self, repository: RealTajoCalendarRepository) -> None:
+        """Initialize the use case with its repository dependency."""
+
+        self._repository = repository
+
+    def execute(self) -> RealTajoCalendar | None:
+        """Return the stored calendar aggregate or ``None`` when absent."""
+
+        return self._repository.load()

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -13,6 +13,7 @@ class Settings:
     data_dir: Path = Path("data")
     classification_filename: str = "classification.json"
     schedule_filename: str = "schedule.json"
+    real_tajo_calendar_filename: str = "real_tajo_calendar.json"
     app_version: str = "0.1.0"
     api_version: str = "v1"
     allowed_origins: Tuple[str, ...] = ("*",)
@@ -29,6 +30,12 @@ class Settings:
         """Return the full path for storing schedule data."""
 
         return self.data_dir / self.schedule_filename
+
+    @property
+    def real_tajo_calendar_path(self) -> Path:
+        """Return the full path for storing the Real Tajo calendar data."""
+
+        return self.data_dir / self.real_tajo_calendar_filename
 
     @property
     def api_prefix(self) -> str:

--- a/src/app/domain/models/real_tajo_calendar.py
+++ b/src/app/domain/models/real_tajo_calendar.py
@@ -1,0 +1,99 @@
+"""Domain models representing the Real Tajo calendar document."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class KitDetails:
+    """Describe the kit configuration for a team."""
+
+    shirt_type: str | None = None
+    shorts_type: str | None = None
+    socks_type: str | None = None
+    shirt: str | None = None
+    shorts: str | None = None
+    socks: str | None = None
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the kit."""
+
+        return {
+            "shirt_type": self.shirt_type,
+            "shorts_type": self.shorts_type,
+            "socks_type": self.socks_type,
+            "shirt": self.shirt,
+            "shorts": self.shorts,
+            "socks": self.socks,
+        }
+
+
+@dataclass(frozen=True)
+class TeamDetails:
+    """Represent the general information of Real Tajo."""
+
+    contact: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    primary_kit: KitDetails = field(default_factory=KitDetails)
+    secondary_kit: KitDetails = field(default_factory=KitDetails)
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the team details."""
+
+        return {
+            "contact": self.contact,
+            "address": self.address,
+            "phone": self.phone,
+            "primary_kit": self.primary_kit.to_dict(),
+            "secondary_kit": self.secondary_kit.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class RealTajoFixture:
+    """Represent a single Real Tajo fixture within the calendar."""
+
+    stage: str
+    round_number: int
+    date: str
+    opponent: str
+    venue: str
+    home_team: str
+    away_team: str
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the fixture."""
+
+        return {
+            "stage": self.stage,
+            "round": self.round_number,
+            "date": self.date,
+            "opponent": self.opponent,
+            "venue": self.venue,
+            "home_team": self.home_team,
+            "away_team": self.away_team,
+        }
+
+
+@dataclass(frozen=True)
+class RealTajoCalendar:
+    """Aggregate the calendar and team details extracted from the document."""
+
+    team: str
+    competition: str
+    season: str
+    fixtures: List[RealTajoFixture] = field(default_factory=list)
+    team_details: TeamDetails = field(default_factory=TeamDetails)
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the calendar."""
+
+        return {
+            "team": self.team,
+            "competition": self.competition,
+            "season": self.season,
+            "fixtures": [fixture.to_dict() for fixture in self.fixtures],
+            "team_details": self.team_details.to_dict(),
+        }

--- a/src/app/domain/repositories/real_tajo_calendar_repository.py
+++ b/src/app/domain/repositories/real_tajo_calendar_repository.py
@@ -1,0 +1,16 @@
+"""Repository interface dedicated to Real Tajo calendar data."""
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+from app.domain.models.real_tajo_calendar import RealTajoCalendar
+
+
+class RealTajoCalendarRepository(Protocol):
+    """Persist and retrieve Real Tajo calendar aggregates."""
+
+    def save(self, calendar: RealTajoCalendar) -> None:
+        """Persist the provided calendar aggregate."""
+
+    def load(self) -> Optional[RealTajoCalendar]:
+        """Retrieve the stored calendar aggregate if available."""

--- a/src/app/domain/services/real_tajo_calendar_extractor.py
+++ b/src/app/domain/services/real_tajo_calendar_extractor.py
@@ -1,0 +1,184 @@
+"""Domain service that extracts Real Tajo information from a parsed document."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+from app.domain.models.document import ParsedDocument
+from app.domain.models.real_tajo_calendar import (
+    KitDetails,
+    RealTajoCalendar,
+    RealTajoFixture,
+    TeamDetails,
+)
+
+
+class RealTajoCalendarExtractorService:
+    """Build a Real Tajo calendar aggregate from a parsed document."""
+
+    TEAM_NAME = "REAL TAJO"
+
+    def extract(self, document: ParsedDocument) -> RealTajoCalendar:
+        """Convert the provided document into a Real Tajo calendar aggregate."""
+
+        if not document.pages:
+            raise ValueError("The document does not contain any pages.")
+
+        competition, season = self._extract_competition_and_season(document)
+        fixtures = self._extract_fixtures(document)
+        if not fixtures:
+            raise ValueError("No fixtures for REAL TAJO were found in the document.")
+        team_details = self._extract_team_details(document)
+
+        return RealTajoCalendar(
+            team=self.TEAM_NAME,
+            competition=competition,
+            season=season,
+            fixtures=fixtures,
+            team_details=team_details,
+        )
+
+    def _extract_competition_and_season(self, document: ParsedDocument) -> tuple[str, str]:
+        for line in self._iter_lines(document):
+            if "Temporada" in line:
+                prefix, _, suffix = line.partition("Temporada")
+                competition = prefix.strip(" ,")
+                season = suffix.strip()
+                if competition and season:
+                    return competition, season
+        raise ValueError("Unable to determine competition and season information.")
+
+    def _extract_fixtures(self, document: ParsedDocument) -> List[RealTajoFixture]:
+        fixtures: List[RealTajoFixture] = []
+        stage = ""
+        current_round: int | None = None
+        current_date: str | None = None
+        buffer = ""
+
+        for line in self._iter_lines(document):
+            normalized_line = line.strip()
+            if normalized_line.lower() in {"primera vuelta", "segunda vuelta"}:
+                stage = normalized_line.title()
+                continue
+
+            round_match = re.match(r"Jornada\s+(\d+)\s+\(([^)]+)\)", normalized_line)
+            if round_match:
+                current_round = int(round_match.group(1))
+                current_date = round_match.group(2).strip()
+                buffer = ""
+                continue
+
+            if not normalized_line:
+                continue
+
+            buffer = f"{buffer} {normalized_line}".strip()
+            if " - " not in buffer or current_round is None or current_date is None:
+                continue
+
+            home_team, away_team = [part.strip() for part in buffer.split(" - ", 1)]
+            buffer = ""
+
+            if not home_team or not away_team:
+                continue
+
+            upper_home = home_team.upper()
+            upper_away = away_team.upper()
+            if self.TEAM_NAME not in {upper_home, upper_away}:
+                continue
+
+            venue = "home" if upper_home == self.TEAM_NAME else "away"
+            opponent = away_team if venue == "home" else home_team
+
+            fixtures.append(
+                RealTajoFixture(
+                    stage=stage,
+                    round_number=current_round,
+                    date=current_date,
+                    opponent=opponent,
+                    venue=venue,
+                    home_team=home_team,
+                    away_team=away_team,
+                )
+            )
+
+        return fixtures
+
+    def _extract_team_details(self, document: ParsedDocument) -> TeamDetails:
+        lines = list(self._iter_lines(document))
+        target_index = self._find_detail_index(lines)
+        if target_index is None:
+            raise ValueError("Unable to locate Real Tajo team details in the document.")
+
+        block_end = self._find_block_end(lines, target_index)
+        block = lines[target_index:block_end]
+
+        contact = self._extract_after_label(block[0], "Contacto:")
+
+        address = next(
+            (
+                line
+                for line in block[1:]
+                if not line.startswith("Teléfono:") and "Equipación" not in line and ":" not in line
+            ),
+            None,
+        )
+
+        phone_line = next((line for line in block if line.startswith("Teléfono:")), None)
+        phone = self._extract_after_label(phone_line, "Teléfono:") if phone_line else None
+
+        primary_kit = self._extract_kit(block, "Primera Equipación")
+        secondary_kit = self._extract_kit(block, "2ª Equipación")
+
+        return TeamDetails(
+            contact=contact or None,
+            address=address or None,
+            phone=phone or None,
+            primary_kit=primary_kit,
+            secondary_kit=secondary_kit,
+        )
+
+    def _extract_kit(self, block: List[str], heading: str) -> KitDetails:
+        try:
+            heading_index = block.index(heading)
+        except ValueError:
+            return KitDetails()
+
+        type_line = block[heading_index + 1] if heading_index + 1 < len(block) else ""
+        color_line = block[heading_index + 2] if heading_index + 2 < len(block) else ""
+        type_values = self._parse_colon_separated_values(type_line)
+        color_values = self._parse_colon_separated_values(color_line)
+        return KitDetails(
+            shirt_type=type_values.get("Tipo Camiseta"),
+            shorts_type=type_values.get("Tipo Pantalón"),
+            socks_type=type_values.get("Tipo Medias"),
+            shirt=color_values.get("Camiseta"),
+            shorts=color_values.get("Pantalón"),
+            socks=color_values.get("Medias"),
+        )
+
+    def _find_block_end(self, lines: List[str], start_index: int) -> int:
+        for index in range(start_index + 1, len(lines)):
+            line = lines[index]
+            if "Contacto:" in line and self.TEAM_NAME not in line.upper():
+                return index
+        return len(lines)
+
+    def _parse_colon_separated_values(self, line: str) -> dict[str, str | None]:
+        pattern = r"([^:]+):\s*([^:]+?)(?=\s+[^:]+:|$)"
+        return {match.group(1).strip(): match.group(2).strip() or None for match in re.finditer(pattern, line)}
+
+    def _extract_after_label(self, text: str | None, label: str) -> str | None:
+        if text is None or label not in text:
+            return None
+        return text.split(label, 1)[1].strip() or None
+
+    def _find_detail_index(self, lines: List[str]) -> int | None:
+        for index, line in enumerate(lines):
+            if line.upper().startswith(f"{self.TEAM_NAME} CONTACTO:") or "REAL TAJO Contacto:" in line:
+                return index
+        return None
+
+    def _iter_lines(self, document: ParsedDocument) -> Iterable[str]:
+        for page in document.pages:
+            for line in page.content:
+                yield line

--- a/src/app/infrastructure/repositories/json_real_tajo_calendar_repository.py
+++ b/src/app/infrastructure/repositories/json_real_tajo_calendar_repository.py
@@ -1,0 +1,107 @@
+"""Repository storing Real Tajo calendar aggregates as JSON files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from app.domain.models.real_tajo_calendar import (
+    KitDetails,
+    RealTajoCalendar,
+    RealTajoFixture,
+    TeamDetails,
+)
+from app.domain.repositories.real_tajo_calendar_repository import RealTajoCalendarRepository
+
+
+class JsonRealTajoCalendarRepository(RealTajoCalendarRepository):
+    """Persist Real Tajo calendar aggregates on disk as JSON."""
+
+    def __init__(self, file_path: Path) -> None:
+        """Initialize the repository with the path where data will be stored."""
+
+        self._file_path = file_path
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def save(self, calendar: RealTajoCalendar) -> None:
+        """Serialize and persist the calendar aggregate."""
+
+        with self._file_path.open("w", encoding="utf-8") as output_file:
+            json.dump(calendar.to_dict(), output_file, ensure_ascii=False, indent=2)
+
+    def load(self) -> Optional[RealTajoCalendar]:
+        """Load the stored calendar aggregate, returning ``None`` when absent."""
+
+        if not self._file_path.exists():
+            return None
+
+        with self._file_path.open("r", encoding="utf-8") as input_file:
+            data = json.load(input_file)
+
+        return self._deserialize_calendar(data)
+
+    def _deserialize_calendar(self, data: dict) -> RealTajoCalendar:
+        team = data.get("team", "REAL TAJO")
+        competition = data.get("competition", "")
+        season = data.get("season", "")
+        fixtures = [self._deserialize_fixture(item) for item in data.get("fixtures", [])]
+        team_details = self._deserialize_team_details(data.get("team_details", {}))
+        return RealTajoCalendar(
+            team=team,
+            competition=competition,
+            season=season,
+            fixtures=fixtures,
+            team_details=team_details,
+        )
+
+    def _deserialize_fixture(self, data: dict) -> RealTajoFixture:
+        stage = data.get("stage", "")
+        round_number = data.get("round", 0)
+        date = data.get("date", "")
+        opponent = data.get("opponent", "")
+        venue = data.get("venue", "")
+        home_team = data.get("home_team", "")
+        away_team = data.get("away_team", "")
+        try:
+            round_value = int(round_number)
+        except (TypeError, ValueError):
+            round_value = 0
+        return RealTajoFixture(
+            stage=str(stage),
+            round_number=round_value,
+            date=str(date),
+            opponent=str(opponent),
+            venue=str(venue),
+            home_team=str(home_team),
+            away_team=str(away_team),
+        )
+
+    def _deserialize_team_details(self, data: dict) -> TeamDetails:
+        contact = data.get("contact")
+        address = data.get("address")
+        phone = data.get("phone")
+        primary = self._deserialize_kit(data.get("primary_kit", {}))
+        secondary = self._deserialize_kit(data.get("secondary_kit", {}))
+        return TeamDetails(
+            contact=str(contact) if contact is not None else None,
+            address=str(address) if address is not None else None,
+            phone=str(phone) if phone is not None else None,
+            primary_kit=primary,
+            secondary_kit=secondary,
+        )
+
+    def _deserialize_kit(self, data: dict) -> KitDetails:
+        return KitDetails(
+            shirt_type=self._optional_str(data.get("shirt_type")),
+            shorts_type=self._optional_str(data.get("shorts_type")),
+            socks_type=self._optional_str(data.get("socks_type")),
+            shirt=self._optional_str(data.get("shirt")),
+            shorts=self._optional_str(data.get("shorts")),
+            socks=self._optional_str(data.get("socks")),
+        )
+
+    def _optional_str(self, value: object) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration ensuring application modules are importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_json_real_tajo_calendar_repository.py
+++ b/tests/test_json_real_tajo_calendar_repository.py
@@ -1,0 +1,55 @@
+"""Tests for the JSON repository persisting Real Tajo calendar data."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.domain.models.real_tajo_calendar import (
+    KitDetails,
+    RealTajoCalendar,
+    RealTajoFixture,
+    TeamDetails,
+)
+from app.infrastructure.repositories.json_real_tajo_calendar_repository import (
+    JsonRealTajoCalendarRepository,
+)
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    """Saving and loading should preserve the calendar aggregate."""
+
+    repository = JsonRealTajoCalendarRepository(tmp_path / "calendar.json")
+    calendar = RealTajoCalendar(
+        team="REAL TAJO",
+        competition="LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11",
+        season="2025-2026",
+        fixtures=[
+            RealTajoFixture(
+                stage="Primera Vuelta",
+                round_number=1,
+                date="11-10-2025",
+                opponent="RACING ARANJUEZ",
+                venue="home",
+                home_team="REAL TAJO",
+                away_team="RACING ARANJUEZ",
+            )
+        ],
+        team_details=TeamDetails(
+            contact="JUAN",
+            address="28300 Aranjuez (Madrid)",
+            phone="620763145",
+            primary_kit=KitDetails(
+                shirt_type="Lisa",
+                shorts_type="Base",
+                socks_type="Base",
+                shirt="Azul",
+                shorts="Azul",
+                socks="Blancas",
+            ),
+            secondary_kit=KitDetails(),
+        ),
+    )
+
+    repository.save(calendar)
+    loaded_calendar = repository.load()
+
+    assert loaded_calendar == calendar

--- a/tests/test_real_tajo_calendar_extractor.py
+++ b/tests/test_real_tajo_calendar_extractor.py
@@ -1,0 +1,93 @@
+"""Tests covering the Real Tajo calendar extraction service."""
+from __future__ import annotations
+
+from app.domain.models.document import DocumentPage, ParsedDocument
+from app.domain.services.real_tajo_calendar_extractor import (
+    RealTajoCalendarExtractorService,
+)
+
+
+def build_sample_document() -> ParsedDocument:
+    """Create a parsed document mimicking the provided schedule PDF."""
+
+    page_one = DocumentPage(
+        number=1,
+        content=[
+            "Calendario de Competiciones",
+            "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Equipos Participantes",
+            "REAL TAJO",
+        ],
+    )
+
+    page_two = DocumentPage(
+        number=2,
+        content=[
+            "Calendario de Competiciones",
+            "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Primera Vuelta",
+            "Jornada 1 (11-10-2025)",
+            "NUEVO - AMERICA",
+            "REAL TAJO - RACING ARANJUEZ",
+            "Segunda Vuelta",
+            "Jornada 10 (31-01-2026)",
+            "AMERICA - NUEVO",
+            "RACING ARANJUEZ - REAL TAJO",
+            "Jornada 14 (21-03-2026)",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - REAL TAJO",
+        ],
+    )
+
+    page_three = DocumentPage(
+        number=3,
+        content=[
+            "Datos de interés de los equipos participantes",
+            "REAL TAJO Contacto: JUAN",
+            "28300 Aranjuez (Madrid)",
+            "Teléfono: 620763145",
+            "Primera Equipación",
+            "Tipo Camiseta: Lisa Tipo Pantalón: Base Tipo Medias: Base",
+            "Camiseta: Azul Pantalón: Azul Medias: Blancas",
+            "2ª Equipación",
+            "Camiseta: - Pantalón: - Medias: -",
+        ],
+    )
+
+    return ParsedDocument(pages=[page_one, page_two, page_three])
+
+
+def test_real_tajo_calendar_extraction() -> None:
+    """The extractor should assemble the calendar and details for Real Tajo."""
+
+    extractor = RealTajoCalendarExtractorService()
+    calendar = extractor.extract(build_sample_document())
+
+    assert calendar.team == "REAL TAJO"
+    assert calendar.competition == "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11"
+    assert calendar.season == "2025-2026"
+
+    assert len(calendar.fixtures) == 3
+
+    first_fixture = calendar.fixtures[0]
+    assert first_fixture.stage == "Primera Vuelta"
+    assert first_fixture.round_number == 1
+    assert first_fixture.date == "11-10-2025"
+    assert first_fixture.venue == "home"
+    assert first_fixture.opponent == "RACING ARANJUEZ"
+
+    second_fixture = calendar.fixtures[1]
+    assert second_fixture.stage == "Segunda Vuelta"
+    assert second_fixture.venue == "away"
+    assert second_fixture.opponent == "RACING ARANJUEZ"
+
+    third_fixture = calendar.fixtures[2]
+    assert third_fixture.opponent == "AMG-ASESORIA JURIDICA- EXCAVACIONES TAJO"
+
+    details = calendar.team_details
+    assert details.contact == "JUAN"
+    assert details.address == "28300 Aranjuez (Madrid)"
+    assert details.phone == "620763145"
+    assert details.primary_kit.shirt == "Azul"
+    assert details.primary_kit.shirt_type == "Lisa"
+    assert details.secondary_kit.shirt is None


### PR DESCRIPTION
## Summary
- add a dedicated domain model, extractor service and JSON repository for the Real Tajo calendar document
- expose upload and retrieval endpoints for the Real Tajo calendar alongside configuration hooks
- cover the new extractor and repository with unit tests and ensure pytest discovers project packages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f671ffc083338b2e54dd4738ea27