### PR TITLE
Handle inline fixtures in Real Tajo calendar parser

### DIFF
--- a/src/app/application/process_real_tajo_calendar.py
+++ b/src/app/application/process_real_tajo_calendar.py
@@ -1,0 +1,51 @@
+"""Use cases for processing and retrieving Real Tajo calendar documents."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.models.real_tajo_calendar import RealTajoCalendar
+from app.domain.repositories.real_tajo_calendar_repository import (
+    RealTajoCalendarRepository,
+)
+
+
+class RealTajoCalendarParser(Protocol):
+    """Represent a service capable of decoding a Real Tajo calendar from PDF bytes."""
+
+    def parse(self, document_bytes: bytes) -> RealTajoCalendar:
+        """Convert raw PDF bytes into a ``RealTajoCalendar`` domain model."""
+
+
+class ProcessRealTajoCalendarUseCase:
+    """Handle ingestion, parsing and persistence of Real Tajo calendars."""
+
+    def __init__(
+        self,
+        parser: RealTajoCalendarParser,
+        repository: RealTajoCalendarRepository,
+    ) -> None:
+        """Initialize the use case with its dependencies."""
+
+        self._parser = parser
+        self._repository = repository
+
+    def execute(self, document_bytes: bytes) -> RealTajoCalendar:
+        """Parse the calendar PDF and persist the resulting model."""
+
+        calendar = self._parser.parse(document_bytes)
+        self._repository.save(calendar)
+        return calendar
+
+
+class RetrieveRealTajoCalendarUseCase:
+    """Retrieve the last processed Real Tajo calendar if available."""
+
+    def __init__(self, repository: RealTajoCalendarRepository) -> None:
+        """Initialize the use case with the repository dependency."""
+
+        self._repository = repository
+
+    def execute(self) -> RealTajoCalendar | None:
+        """Return the stored calendar or ``None`` when absent."""
+
+        return self._repository.load()

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -13,6 +13,7 @@ class Settings:
     data_dir: Path = Path("data")
     classification_filename: str = "classification.json"
     schedule_filename: str = "schedule.json"
+    real_tajo_calendar_filename: str = "real_tajo_calendar.json"
     app_version: str = "0.1.0"
     api_version: str = "v1"
     allowed_origins: Tuple[str, ...] = ("*",)
@@ -29,6 +30,12 @@ class Settings:
         """Return the full path for storing schedule data."""
 
         return self.data_dir / self.schedule_filename
+
+    @property
+    def real_tajo_calendar_path(self) -> Path:
+        """Return the storage path for the Real Tajo calendar data."""
+
+        return self.data_dir / self.real_tajo_calendar_filename
 
     @property
     def api_prefix(self) -> str:

--- a/src/app/domain/models/real_tajo_calendar.py
+++ b/src/app/domain/models/real_tajo_calendar.py
@@ -1,0 +1,189 @@
+"""Domain models describing Real Tajo's calendar extracted from competition PDFs."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class RealTajoKit:
+    """Represent the kit information for a Real Tajo uniform."""
+
+    shirt: Optional[str] = None
+    shorts: Optional[str] = None
+    socks: Optional[str] = None
+    shirt_type: Optional[str] = None
+    shorts_type: Optional[str] = None
+    socks_type: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Return a JSON-serializable representation of the kit."""
+
+        return {
+            "shirt": self.shirt,
+            "shorts": self.shorts,
+            "socks": self.socks,
+            "shirt_type": self.shirt_type,
+            "shorts_type": self.shorts_type,
+            "socks_type": self.socks_type,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Optional[str]]) -> "RealTajoKit":
+        """Create a kit instance from a JSON-compatible dictionary."""
+
+        return cls(
+            shirt=data.get("shirt"),
+            shorts=data.get("shorts"),
+            socks=data.get("socks"),
+            shirt_type=data.get("shirt_type"),
+            shorts_type=data.get("shorts_type"),
+            socks_type=data.get("socks_type"),
+        )
+
+
+@dataclass(frozen=True)
+class RealTajoTeamInfo:
+    """Represent the general information of the Real Tajo club."""
+
+    name: str
+    contact_name: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[str] = None
+    first_kit: RealTajoKit = field(default_factory=RealTajoKit)
+    second_kit: RealTajoKit = field(default_factory=RealTajoKit)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serializable representation of the team information."""
+
+        return {
+            "name": self.name,
+            "contact_name": self.contact_name,
+            "phone": self.phone,
+            "address": self.address,
+            "first_kit": self.first_kit.to_dict(),
+            "second_kit": self.second_kit.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "RealTajoTeamInfo":
+        """Create a team information instance from its dictionary representation."""
+
+        first_kit_data = data.get("first_kit")
+        second_kit_data = data.get("second_kit")
+        first_kit = (
+            RealTajoKit.from_dict(first_kit_data)
+            if isinstance(first_kit_data, dict)
+            else RealTajoKit()
+        )
+        second_kit = (
+            RealTajoKit.from_dict(second_kit_data)
+            if isinstance(second_kit_data, dict)
+            else RealTajoKit()
+        )
+
+        return cls(
+            name=str(data.get("name", "REAL TAJO")),
+            contact_name=data.get("contact_name") if data else None,
+            phone=data.get("phone") if data else None,
+            address=data.get("address") if data else None,
+            first_kit=first_kit,
+            second_kit=second_kit,
+        )
+
+
+@dataclass(frozen=True)
+class RealTajoMatch:
+    """Represent a single Real Tajo fixture within the competition calendar."""
+
+    stage: str
+    matchday: int
+    match_date: date
+    opponent: str
+    is_home: bool
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serializable representation of the match."""
+
+        return {
+            "stage": self.stage,
+            "matchday": self.matchday,
+            "date": self.match_date.isoformat(),
+            "opponent": self.opponent,
+            "is_home": self.is_home,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "RealTajoMatch":
+        """Create a match instance from a dictionary representation."""
+
+        raw_date = data.get("date")
+        parsed_date = None
+        if isinstance(raw_date, str):
+            try:
+                parsed_date = datetime.strptime(raw_date, "%Y-%m-%d").date()
+            except ValueError:
+                parsed_date = None
+
+        matchday_value = data.get("matchday")
+        try:
+            matchday = int(matchday_value) if matchday_value is not None else 0
+        except (TypeError, ValueError):
+            matchday = 0
+
+        return cls(
+            stage=str(data.get("stage", "")),
+            matchday=matchday,
+            match_date=parsed_date or date.min,
+            opponent=str(data.get("opponent", "")),
+            is_home=bool(data.get("is_home", False)),
+        )
+
+
+@dataclass(frozen=True)
+class RealTajoCalendar:
+    """Aggregate the Real Tajo calendar and related club information."""
+
+    competition: Optional[str]
+    season: Optional[str]
+    matches: List[RealTajoMatch] = field(default_factory=list)
+    team_info: RealTajoTeamInfo = field(default_factory=lambda: RealTajoTeamInfo(name="REAL TAJO"))
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serializable representation of the calendar."""
+
+        return {
+            "competition": self.competition,
+            "season": self.season,
+            "matches": [match.to_dict() for match in self.matches],
+            "team_info": self.team_info.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "RealTajoCalendar":
+        """Create a calendar instance from a dictionary representation."""
+
+        matches_data = data.get("matches") if isinstance(data, dict) else None
+        matches: List[RealTajoMatch] = []
+        if isinstance(matches_data, list):
+            matches = [
+                RealTajoMatch.from_dict(item) for item in matches_data if isinstance(item, dict)
+            ]
+
+        team_info_data = data.get("team_info") if isinstance(data, dict) else None
+        team_info = (
+            RealTajoTeamInfo.from_dict(team_info_data)
+            if isinstance(team_info_data, dict)
+            else RealTajoTeamInfo(name="REAL TAJO")
+        )
+
+        competition = data.get("competition") if isinstance(data, dict) else None
+        season = data.get("season") if isinstance(data, dict) else None
+
+        return cls(
+            competition=str(competition) if competition is not None else None,
+            season=str(season) if season is not None else None,
+            matches=matches,
+            team_info=team_info,
+        )

--- a/src/app/domain/repositories/real_tajo_calendar_repository.py
+++ b/src/app/domain/repositories/real_tajo_calendar_repository.py
@@ -1,0 +1,16 @@
+"""Repository contract for persisting Real Tajo calendars."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.models.real_tajo_calendar import RealTajoCalendar
+
+
+class RealTajoCalendarRepository(Protocol):
+    """Define the operations required to persist Real Tajo calendar data."""
+
+    def save(self, calendar: RealTajoCalendar) -> None:
+        """Persist the provided Real Tajo calendar."""
+
+    def load(self) -> RealTajoCalendar | None:
+        """Retrieve the stored Real Tajo calendar if any is available."""

--- a/src/app/infrastructure/parsers/real_tajo_calendar_parser.py
+++ b/src/app/infrastructure/parsers/real_tajo_calendar_parser.py
@@ -1,0 +1,332 @@
+"""Parser that extracts Real Tajo specific information from competition PDFs."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import datetime
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from app.application.process_document import DocumentParser
+from app.application.process_real_tajo_calendar import RealTajoCalendarParser
+from app.domain.models.document import ParsedDocument
+from app.domain.models.real_tajo_calendar import (
+    RealTajoCalendar,
+    RealTajoKit,
+    RealTajoMatch,
+    RealTajoTeamInfo,
+)
+from app.infrastructure.parsers.pdf_document_parser import PdfDocumentParser
+
+
+class RealTajoCalendarPdfParser(RealTajoCalendarParser):
+    """Decode Real Tajo calendar information from uploaded PDF documents."""
+
+    def __init__(self, document_parser: DocumentParser | None = None) -> None:
+        """Initialize the parser optionally providing a custom document parser."""
+
+        self._document_parser = document_parser or PdfDocumentParser()
+
+    def parse(self, document_bytes: bytes) -> RealTajoCalendar:
+        """Parse the PDF bytes and return the Real Tajo calendar model."""
+
+        parsed_document = self._document_parser.parse(document_bytes)
+        lines = list(_iterate_lines(parsed_document))
+
+        competition, season = _extract_competition_and_season(lines)
+        team_names = _extract_team_names(lines)
+        matches = _extract_real_tajo_matches(lines, team_names)
+        team_info = _extract_team_info(lines)
+
+        if not matches:
+            raise ValueError("No Real Tajo fixtures were found in the provided calendar.")
+
+        if team_info is None:
+            team_info = RealTajoTeamInfo(name="REAL TAJO")
+
+        return RealTajoCalendar(
+            competition=competition,
+            season=season,
+            matches=matches,
+            team_info=team_info,
+        )
+
+
+def _iterate_lines(parsed_document: ParsedDocument) -> Iterable[str]:
+    """Yield normalized lines from the parsed document."""
+
+    for page in parsed_document.pages:
+        for line in page.content:
+            normalized = _normalize_text(line)
+            if normalized:
+                yield normalized
+
+
+def _normalize_text(text: str) -> str:
+    """Collapse whitespace within ``text`` and strip leading or trailing spaces."""
+
+    collapsed = " ".join(text.replace("\xa0", " ").split())
+    return collapsed.strip()
+
+
+def _extract_competition_and_season(lines: Sequence[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Retrieve competition name and season from the document header."""
+
+    for line in lines:
+        if "Temporada" not in line:
+            continue
+        parts = line.split("Temporada", maxsplit=1)
+        if len(parts) != 2:
+            continue
+        competition = parts[0].rstrip(", ") or None
+        season = parts[1].strip() or None
+        return competition, season
+    return None, None
+
+
+TEAM_LINE_PATTERN = re.compile(r"^(\d+)\.\-\s+(.+?)\s*(?:\(\d+\))?$")
+
+
+def _extract_team_names(lines: Sequence[str]) -> List[str]:
+    """Collect the registered team names listed in the calendar."""
+
+    team_names: List[str] = []
+    capture = False
+    for line in lines:
+        if not capture and line.lower().startswith("equipos participantes"):
+            capture = True
+            continue
+        if capture:
+            if line.lower().startswith("delegacion"):
+                break
+            match = TEAM_LINE_PATTERN.match(line)
+            if match:
+                team_names.append(match.group(2).strip())
+    if "REAL TAJO" not in team_names:
+        team_names.append("REAL TAJO")
+    return team_names
+
+
+def _extract_real_tajo_matches(lines: Sequence[str], team_names: Sequence[str]) -> List[RealTajoMatch]:
+    """Extract and filter matches that involve Real Tajo from the schedule."""
+
+    sorted_names = sorted(team_names, key=len, reverse=True)
+    real_tajo_name = next(
+        (team for team in team_names if "REAL TAJO" in team.upper()),
+        "REAL TAJO",
+    )
+
+    matches: List[RealTajoMatch] = []
+    current_stage: Optional[str] = None
+    current_matchday: Optional[int] = None
+    current_date: Optional[datetime] = None
+    buffer = ""
+
+    jornada_pattern = re.compile(r"Jornada\s+(\d+)\s*\((\d{2}-\d{2}-\d{4})\)")
+
+    for line in lines:
+        lower_line = line.lower()
+        if "primera vuelta" in lower_line:
+            current_stage = "Primera Vuelta"
+            current_matchday = None
+            buffer = ""
+
+        if "segunda vuelta" in lower_line:
+            current_stage = "Segunda Vuelta"
+            current_matchday = None
+            buffer = ""
+
+        jornada_match = jornada_pattern.search(line)
+        if jornada_match:
+            current_matchday = int(jornada_match.group(1))
+            current_date = datetime.strptime(jornada_match.group(2), "%d-%m-%Y")
+            buffer = ""
+            remaining = line[jornada_match.end() :].strip()
+            if remaining:
+                buffer = remaining
+
+        if current_stage is None or current_matchday is None or current_date is None:
+            continue
+
+        if line.startswith("Calendario de Competiciones") or line.startswith("DELEGACION"):
+            continue
+
+        if not jornada_match and not _is_stage_line(lower_line):
+            buffer = f"{buffer} {line}".strip() if buffer else line
+
+        buffer = buffer.strip()
+        while buffer:
+            parsed_match = _parse_match(buffer, sorted_names)
+            if parsed_match is None:
+                break
+
+            home_team, away_team, consumed = parsed_match
+            buffer = buffer[consumed:].lstrip(" -,.\n")
+
+            if real_tajo_name not in (home_team, away_team):
+                continue
+
+            opponent = away_team if home_team == real_tajo_name else home_team
+            matches.append(
+                RealTajoMatch(
+                    stage=current_stage,
+                    matchday=current_matchday,
+                    match_date=current_date.date(),
+                    opponent=opponent,
+                    is_home=home_team == real_tajo_name,
+                )
+            )
+
+    return matches
+
+
+def _is_stage_line(lower_line: str) -> bool:
+    """Return ``True`` when the provided line represents a competition stage."""
+
+    return "primera vuelta" in lower_line or "segunda vuelta" in lower_line
+
+
+def _parse_match(text: str, team_names: Sequence[str]) -> Optional[Tuple[str, str, int]]:
+    """Attempt to extract the next match from ``text`` splitting by known team names."""
+
+    if " - " not in text:
+        return None
+
+    for home_team in team_names:
+        prefix = f"{home_team} - "
+        if not text.startswith(prefix):
+            continue
+        remainder = text[len(prefix) :]
+        for away_team in team_names:
+            if remainder.startswith(away_team):
+                consumed = len(prefix) + len(away_team)
+                return home_team, away_team, consumed
+    return None
+
+
+KIT_PAIR_PATTERN = re.compile(
+    r"([A-Za-zÁÉÍÓÚÜÑáéíóúüñ0-9ºª'().-]+(?:\s+[A-Za-zÁÉÍÓÚÜÑáéíóúüñ0-9ºª'().-]+)*):\s*"
+    r"([^:]+?)(?=(?:\s+[A-Za-zÁÉÍÓÚÜÑáéíóúüñ0-9ºª'().-]+(?:\s+[A-Za-zÁÉÍÓÚÜÑáéíóúüñ0-9ºª'().-]+)*:)|$)"
+)
+
+
+def _extract_team_info(lines: Sequence[str]) -> Optional[RealTajoTeamInfo]:
+    """Extract contact and kit information specific to Real Tajo."""
+
+    for index, line in enumerate(lines):
+        if not line.upper().startswith("REAL TAJO"):
+            continue
+
+        has_contact_marker = "Contacto" in line
+        next_line = lines[index + 1] if index + 1 < len(lines) else ""
+        if not has_contact_marker and "Contacto" not in next_line:
+            continue
+
+        contact_name: Optional[str] = None
+        phone: Optional[str] = None
+        address: Optional[str] = None
+
+        contact_match = re.search(r"Contacto:\s*(.+)", line)
+        if contact_match:
+            contact_name = contact_match.group(1).strip() or None
+
+        lookahead = index + 1
+        if contact_name is None and lookahead < len(lines):
+            contact_line = lines[lookahead]
+            if "Contacto:" in contact_line:
+                contact_name = contact_line.split("Contacto:", maxsplit=1)[1].strip() or None
+                lookahead += 1
+
+        if lookahead < len(lines):
+            potential_address = lines[lookahead]
+            if not potential_address.startswith("Teléfono"):
+                address = potential_address
+                lookahead += 1
+
+        if lookahead < len(lines) and "Teléfono" in lines[lookahead]:
+            phone = lines[lookahead].split("Teléfono:", maxsplit=1)[1].strip() or None
+            lookahead += 1
+
+        first_kit, offset = _parse_kit_section(lines, lookahead)
+        lookahead += offset
+        second_kit, _ = _parse_kit_section(lines, lookahead)
+
+        return RealTajoTeamInfo(
+            name="REAL TAJO",
+            contact_name=contact_name,
+            phone=phone,
+            address=address,
+            first_kit=first_kit,
+            second_kit=second_kit,
+        )
+
+    return None
+
+
+def _parse_kit_section(
+    lines: Sequence[str], start_index: int
+) -> Tuple[RealTajoKit, int]:
+    """Parse a kit section starting at ``start_index`` returning the kit and consumed lines."""
+
+    if start_index >= len(lines):
+        return RealTajoKit(), 0
+
+    title = lines[start_index]
+    if "equipación" not in title.lower():
+        return RealTajoKit(), 0
+
+    consumed = 1
+    type_line: Optional[str] = None
+    color_line: Optional[str] = None
+
+    if start_index + consumed < len(lines) and "Tipo" in lines[start_index + consumed]:
+        type_line = lines[start_index + consumed]
+        consumed += 1
+
+    if start_index + consumed < len(lines):
+        color_line = lines[start_index + consumed]
+        consumed += 1
+
+    kit = RealTajoKit()
+    if type_line or color_line:
+        kit = _build_kit(type_line, color_line)
+
+    return kit, consumed
+
+
+def _build_kit(type_line: Optional[str], color_line: Optional[str]) -> RealTajoKit:
+    """Create a ``RealTajoKit`` instance from type and color lines."""
+
+    type_pairs = _parse_pairs(type_line) if type_line else {}
+    color_pairs = _parse_pairs(color_line) if color_line else {}
+
+    return RealTajoKit(
+        shirt=color_pairs.get("camiseta"),
+        shorts=color_pairs.get("pantalon"),
+        socks=color_pairs.get("medias"),
+        shirt_type=type_pairs.get("tipo_camiseta"),
+        shorts_type=type_pairs.get("tipo_pantalon"),
+        socks_type=type_pairs.get("tipo_medias"),
+    )
+
+
+def _parse_pairs(line: str) -> dict[str, str]:
+    """Parse key-value pairs within ``line`` produced by the PDF extractor."""
+
+    pairs: dict[str, str] = {}
+    for raw_key, raw_value in KIT_PAIR_PATTERN.findall(line):
+        key = _normalize_key(raw_key)
+        value = raw_value.strip()
+        if key:
+            pairs[key] = value
+    return pairs
+
+
+def _normalize_key(key: str) -> str:
+    """Normalize a raw key removing accents and special characters."""
+
+    normalized = unicodedata.normalize("NFD", key)
+    without_accents = "".join(char for char in normalized if unicodedata.category(char) != "Mn")
+    cleaned = without_accents.replace("º", "").replace("ª", "").replace("'", "")
+    cleaned = cleaned.replace(".", "").replace("-", " ").strip().lower()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.replace(" ", "_")

--- a/src/app/infrastructure/repositories/json_real_tajo_calendar_repository.py
+++ b/src/app/infrastructure/repositories/json_real_tajo_calendar_repository.py
@@ -1,0 +1,41 @@
+"""Repository that persists Real Tajo calendars as JSON files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from app.domain.models.real_tajo_calendar import RealTajoCalendar
+from app.domain.repositories.real_tajo_calendar_repository import (
+    RealTajoCalendarRepository,
+)
+
+
+class JsonRealTajoCalendarRepository(RealTajoCalendarRepository):
+    """Persist Real Tajo calendars on disk in JSON format."""
+
+    def __init__(self, file_path: Path) -> None:
+        """Initialize the repository with the destination file path."""
+
+        self._file_path = file_path
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def save(self, calendar: RealTajoCalendar) -> None:
+        """Serialize and store the calendar as JSON."""
+
+        with self._file_path.open("w", encoding="utf-8") as output_file:
+            json.dump(calendar.to_dict(), output_file, ensure_ascii=False, indent=2)
+
+    def load(self) -> Optional[RealTajoCalendar]:
+        """Load the stored calendar from disk if available."""
+
+        if not self._file_path.exists():
+            return None
+
+        with self._file_path.open("r", encoding="utf-8") as input_file:
+            data = json.load(input_file)
+
+        if not isinstance(data, dict):
+            return None
+
+        return RealTajoCalendar.from_dict(data)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -13,21 +13,37 @@ from app.application.process_document import (
     ProcessDocumentUseCase,
     RetrieveDocumentUseCase,
 )
+from app.application.process_real_tajo_calendar import (
+    ProcessRealTajoCalendarUseCase,
+    RealTajoCalendarParser,
+    RetrieveRealTajoCalendarUseCase,
+)
 from app.config.settings import get_settings
 from app.domain.repositories.classification_repository import ClassificationRepository
 from app.domain.repositories.document_repository import DocumentRepository
+from app.domain.repositories.real_tajo_calendar_repository import (
+    RealTajoCalendarRepository,
+)
 from app.domain.services.classification_extractor import ClassificationExtractorService
 from app.infrastructure.parsers.pdf_document_parser import PdfDocumentParser
 from app.infrastructure.repositories.json_classification_repository import (
     JsonClassificationRepository,
 )
+from app.infrastructure.parsers.real_tajo_calendar_parser import (
+    RealTajoCalendarPdfParser,
+)
 from app.infrastructure.repositories.json_file_repository import JsonFileRepository
+from app.infrastructure.repositories.json_real_tajo_calendar_repository import (
+    JsonRealTajoCalendarRepository,
+)
 
 
 def create_app(
     document_parser: DocumentParser | None = None,
     classification_repo: ClassificationRepository | None = None,
     schedule_repo: DocumentRepository | None = None,
+    real_tajo_parser: RealTajoCalendarParser | None = None,
+    real_tajo_repo: RealTajoCalendarRepository | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application instance."""
 
@@ -38,6 +54,11 @@ def create_app(
         or JsonClassificationRepository(settings.classification_path)
     )
     schedule_repository = schedule_repo or JsonFileRepository(settings.schedule_path)
+    real_tajo_repository = (
+        real_tajo_repo
+        if real_tajo_repo is not None
+        else JsonRealTajoCalendarRepository(settings.real_tajo_calendar_path)
+    )
 
     classification_extractor = ClassificationExtractorService()
     classification_processor = ProcessClassificationUseCase(
@@ -49,6 +70,12 @@ def create_app(
 
     schedule_processor = ProcessDocumentUseCase(pdf_parser, schedule_repository)
     schedule_retriever = RetrieveDocumentUseCase(schedule_repository)
+    real_tajo_calendar_parser = real_tajo_parser or RealTajoCalendarPdfParser(pdf_parser)
+    real_tajo_calendar_processor = ProcessRealTajoCalendarUseCase(
+        real_tajo_calendar_parser,
+        real_tajo_repository,
+    )
+    real_tajo_calendar_retriever = RetrieveRealTajoCalendarUseCase(real_tajo_repository)
 
     app = FastAPI(title="Document Processor API", version=settings.app_version)
 
@@ -119,6 +146,32 @@ def create_app(
                 detail="No processed schedule document available.",
             )
         return parsed_document.to_dict()
+
+    @api_router.post("/real-tajo/calendar", status_code=status.HTTP_201_CREATED)
+    async def upload_real_tajo_calendar(file: UploadFile = File(...)) -> dict:
+        """Parse and persist the uploaded Real Tajo calendar PDF, returning its JSON form."""
+
+        pdf_bytes = await _read_pdf_bytes(file, settings.max_upload_size_bytes)
+        try:
+            calendar = real_tajo_calendar_processor.execute(pdf_bytes)
+        except ValueError as processing_error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(processing_error),
+            ) from processing_error
+        return calendar.to_dict()
+
+    @api_router.get("/real-tajo/calendar", status_code=status.HTTP_200_OK)
+    async def get_real_tajo_calendar() -> dict:
+        """Retrieve the stored Real Tajo calendar document as JSON."""
+
+        calendar = real_tajo_calendar_retriever.execute()
+        if calendar is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No processed Real Tajo calendar available.",
+            )
+        return calendar.to_dict()
 
     app.include_router(api_router)
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Test configuration ensuring the application package is importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_src_on_path() -> None:
+    """Add the project's ``src`` directory to ``sys.path`` when missing."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    src_path = project_root / "src"
+    src_path_str = str(src_path)
+    if src_path_str not in sys.path:
+        sys.path.insert(0, src_path_str)
+
+
+_ensure_src_on_path()

--- a/tests/test_real_tajo_calendar_parser.py
+++ b/tests/test_real_tajo_calendar_parser.py
@@ -1,0 +1,311 @@
+"""Tests for the Real Tajo calendar PDF parser."""
+from __future__ import annotations
+
+from datetime import date
+
+from app.domain.models.document import DocumentPage, ParsedDocument
+from app.infrastructure.parsers.real_tajo_calendar_parser import (
+    RealTajoCalendarPdfParser,
+)
+
+
+class _StubDocumentParser:
+    """Stub parser returning a pre-defined ``ParsedDocument`` for testing."""
+
+    def __init__(self, document: ParsedDocument) -> None:
+        self._document = document
+
+    def parse(self, document_bytes: bytes) -> ParsedDocument:  # noqa: D401 - protocol compliance
+        """Return the stored document regardless of input."""
+
+        return self._document
+
+
+def _build_sample_document() -> ParsedDocument:
+    """Build a parsed document mimicking the provided competition PDF."""
+
+    page_one = DocumentPage(
+        number=1,
+        content=[
+            "Calendario de Competiciones",
+            "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Equipos Participantes",
+            "AFICIONADOS F-11",
+            "1.- NUEVO (1054)",
+            "2.- LA VESPA TAPAS-CLUB ATLETICO DE ARANJUEZ (1028)",
+            "3.- AMERICA (1052)",
+            "4.- AMG-ASESORIA JURIDICA- EXCAVACIONES TAJO (1027)",
+            "5.- RACING ARANJUEZ (1019)",
+            "6.- CELTIC C.F. (1024)",
+            "7.- REAL SPORT (1047)",
+            "8.- REAL TAJO (1048)",
+            "9.- IRT ARANJUEZ (1049)",
+            "10.- ALBIRROJA (1050)",
+            "DELEGACION ZONAL DE ARANJUEZ R.F.F.M.",
+        ],
+    )
+
+    page_two = DocumentPage(
+        number=2,
+        content=[
+            "Calendario de Competiciones",
+            "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Primera Vuelta",
+            "Jornada 1 (11-10-2025)",
+            "NUEVO - AMERICA",
+            "REAL TAJO - RACING ARANJUEZ",
+            "CELTIC C.F. - REAL SPORT",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - IRT ARANJUEZ",
+            "ALBIRROJA - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "Jornada 2 (18-10-2025)",
+            "AMERICA - ALBIRROJA",
+            "RACING ARANJUEZ - NUEVO",
+            "REAL SPORT - REAL TAJO",
+            "IRT ARANJUEZ - CELTIC C.F.",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "Jornada 3 (25-10-2025)",
+            "AMERICA - RACING ARANJUEZ",
+            "NUEVO - REAL SPORT",
+            "REAL TAJO - IRT ARANJUEZ",
+            "CELTIC C.F. - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "ALBIRROJA - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "Jornada 4 (08-11-2025)",
+            "RACING ARANJUEZ - ALBIRROJA",
+            "REAL SPORT - AMERICA",
+            "IRT ARANJUEZ - NUEVO",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - REAL TAJO",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - CELTIC C.F.",
+            "Jornada 5 (15-11-2025)",
+            "RACING ARANJUEZ - REAL SPORT",
+            "AMERICA - IRT ARANJUEZ",
+            "NUEVO - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "REAL TAJO - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "ALBIRROJA - CELTIC C.F.",
+            "Jornada 6 (29-11-2025)",
+            "REAL SPORT - ALBIRROJA",
+            "IRT ARANJUEZ - RACING ARANJUEZ",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - AMERICA",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - NUEVO",
+            "CELTIC C.F. - REAL TAJO",
+            "Jornada 7 (13-12-2025)",
+            "REAL SPORT - IRT ARANJUEZ",
+            "RACING ARANJUEZ - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "AMERICA - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "NUEVO - CELTIC C.F.",
+            "ALBIRROJA - REAL TAJO",
+            "Jornada 8 (10-01-2026)",
+            "ALBIRROJA - IRT ARANJUEZ",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - REAL SPORT",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - RACING ARANJUEZ",
+            "CELTIC C.F. - AMERICA",
+            "REAL TAJO - NUEVO",
+            "Jornada 9 (24-01-2026)",
+            "IRT ARANJUEZ - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "REAL SPORT - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "RACING ARANJUEZ - CELTIC C.F.",
+            "AMERICA - REAL TAJO",
+            "NUEVO - ALBIRROJA",
+            "Segunda Vuelta",
+            "Jornada 10 (31-01-2026)",
+            "AMERICA - NUEVO",
+            "RACING ARANJUEZ - REAL TAJO",
+            "REAL SPORT - CELTIC C.F.",
+            "IRT ARANJUEZ - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - ALBIRROJA",
+            "Jornada 11 (14-02-2026)",
+            "ALBIRROJA - AMERICA",
+            "NUEVO - RACING ARANJUEZ",
+            "REAL TAJO - REAL SPORT",
+            "CELTIC C.F. - IRT ARANJUEZ",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "Jornada 12 (21-02-2026)",
+            "RACING ARANJUEZ - AMERICA",
+            "REAL SPORT - NUEVO",
+            "IRT ARANJUEZ - REAL TAJO",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - CELTIC C.F.",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - ALBIRROJA",
+            "Jornada 13 (14-03-2026)",
+            "ALBIRROJA - RACING ARANJUEZ",
+            "AMERICA - REAL SPORT",
+            "NUEVO - IRT ARANJUEZ",
+            "REAL TAJO - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "CELTIC C.F. - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "Jornada 14 (21-03-2026)",
+            "REAL SPORT - RACING ARANJUEZ",
+            "IRT ARANJUEZ - AMERICA",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - NUEVO",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - REAL TAJO",
+            "CELTIC C.F. - ALBIRROJA",
+            "Jornada 15 (11-04-2026)",
+            "ALBIRROJA - REAL SPORT",
+            "RACING ARANJUEZ - IRT ARANJUEZ",
+            "AMERICA - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "NUEVO - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "REAL TAJO - CELTIC C.F.",
+            "Jornada 16 (18-04-2026)",
+            "IRT ARANJUEZ - REAL SPORT",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - RACING ARANJUEZ",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - AMERICA",
+            "CELTIC C.F. - NUEVO",
+            "REAL TAJO - ALBIRROJA",
+            "Jornada 17 (09-05-2026)",
+            "IRT ARANJUEZ - ALBIRROJA",
+            "REAL SPORT - LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ",
+            "RACING ARANJUEZ - AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO",
+            "AMERICA - CELTIC C.F.",
+            "NUEVO - REAL TAJO",
+            "Jornada 18 (16-05-2026)",
+            "LA VESPA TAPAS-CLUB ATLETICO DE",
+            "ARANJUEZ - IRT ARANJUEZ",
+            "AMG-ASESORIA JURIDICA- EXCAVACIONES",
+            "TAJO - REAL SPORT",
+            "CELTIC C.F. - RACING ARANJUEZ",
+            "REAL TAJO - AMERICA",
+            "ALBIRROJA - NUEVO",
+        ],
+    )
+
+    page_three = DocumentPage(
+        number=3,
+        content=[
+            "Datos de interés de los equipos participantes",
+            "REAL TAJO Contacto: JUAN",
+            "28300 Aranjuez (Madrid)",
+            "Teléfono: 620763145",
+            "Primera Equipación",
+            "Tipo Camiseta: Lisa Tipo Pantalón: Base Tipo Medias: Base",
+            "Camiseta: Azul Pantalón: Azul Medias: Blancas",
+            "2ª Equipación",
+            "Camiseta: - Pantalon: - Medias: -",
+        ],
+    )
+
+    return ParsedDocument(pages=[page_one, page_two, page_three])
+
+
+def test_parser_extracts_real_tajo_calendar() -> None:
+    """Ensure the parser extracts the Real Tajo schedule and team information."""
+
+    document = _build_sample_document()
+    parser = RealTajoCalendarPdfParser(document_parser=_StubDocumentParser(document))
+
+    calendar = parser.parse(b"binary")
+
+    assert calendar.competition == "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11"
+    assert calendar.season == "2025-2026"
+    assert len(calendar.matches) == 18
+
+    first_match = calendar.matches[0]
+    assert first_match.stage == "Primera Vuelta"
+    assert first_match.matchday == 1
+    assert first_match.match_date == date(2025, 10, 11)
+    assert first_match.is_home is True
+    assert first_match.opponent == "RACING ARANJUEZ"
+
+    last_match = calendar.matches[-1]
+    assert last_match.stage == "Segunda Vuelta"
+    assert last_match.matchday == 18
+    assert last_match.match_date == date(2026, 5, 16)
+    assert last_match.is_home is True
+    assert last_match.opponent == "AMERICA"
+
+    team_info = calendar.team_info
+    assert team_info.name == "REAL TAJO"
+    assert team_info.contact_name == "JUAN"
+    assert team_info.phone == "620763145"
+    assert team_info.address == "28300 Aranjuez (Madrid)"
+    assert team_info.first_kit.shirt == "Azul"
+    assert team_info.first_kit.shirt_type == "Lisa"
+    assert team_info.first_kit.socks == "Blancas"
+
+
+def test_parser_handles_inline_matchdays_and_multiple_matches_per_line() -> None:
+    """Validate the parser when matchdays and fixtures are condensed in a single line."""
+
+    document = ParsedDocument(
+        pages=[
+            DocumentPage(
+                number=1,
+                content=[
+                    "Calendario de Competiciones",
+                    "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+                    "Equipos Participantes",
+                    "AFICIONADOS F-11",
+                    "1.- NUEVO (1054)",
+                    "2.- RACING ARANJUEZ (1019)",
+                    "3.- REAL TAJO (1048)",
+                    "4.- AMERICA (1052)",
+                    "5.- REAL SPORT (1047)",
+                ],
+            ),
+            DocumentPage(
+                number=2,
+                content=[
+                    "Primera Vuelta Jornada 1 (11-10-2025) NUEVO - AMERICA REAL TAJO - RACING ARANJUEZ",
+                    "Segunda Vuelta Jornada 10 (31-01-2026) RACING ARANJUEZ - REAL TAJO REAL SPORT - CELTIC C.F.",
+                ],
+            ),
+            DocumentPage(
+                number=3,
+                content=[
+                    "Datos de interés de los equipos participantes",
+                    "REAL TAJO Contacto: JUAN",
+                    "Teléfono: 620763145",
+                    "Primera Equipación",
+                    "Tipo Camiseta: Lisa Tipo Pantalón: Base Tipo Medias: Base",
+                    "Camiseta: Azul Pantalón: Azul Medias: Blancas",
+                ],
+            ),
+        ]
+    )
+
+    parser = RealTajoCalendarPdfParser(document_parser=_StubDocumentParser(document))
+
+    calendar = parser.parse(b"inline")
+
+    assert len(calendar.matches) == 2
+
+    first_match, second_match = calendar.matches
+    assert first_match.stage == "Primera Vuelta"
+    assert first_match.matchday == 1
+    assert first_match.is_home is True
+    assert first_match.opponent == "RACING ARANJUEZ"
+
+    assert second_match.stage == "Segunda Vuelta"
+    assert second_match.matchday == 10
+    assert second_match.is_home is False
+    assert second_match.opponent == "RACING ARANJUEZ"


### PR DESCRIPTION
## Summary
- improve the Real Tajo calendar parser to detect matchdays and fixtures even when they are condensed into single lines
- support sequential fixture parsing within the same line and skip non-stage content when building the buffer
- add regression coverage to ensure inline matchdays and multi-fixture lines are handled correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f671ffc083338b2e54dd4738ea27