### PR TITLE
Ensure Azure startup compatibility and add health endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,11 +17,17 @@ def _add_src_to_path() -> None:
         sys.path.insert(0, src_dir_str)
 
 
+_add_src_to_path()
+
+from app.main import create_app  # noqa: E402  (requires sys.path update)
+
+app = create_app()
+
+
 def main() -> None:
     """Run the API server using Uvicorn."""
 
-    _add_src_to_path()
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8765, reload=False)
+    uvicorn.run(app, host="0.0.0.0", port=8765, reload=False)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 fastapi==0.110.0
 uvicorn[standard]==0.29.0
 PyPDF2==3.0.1
+gunicorn==23.0.0
+httpx==0.27.0
+python-multipart==0.0.9
+-e .

--- a/server.py
+++ b/server.py
@@ -1,0 +1,36 @@
+"""ASGI entry point compatible with Azure App Service deployments."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+
+
+def _ensure_src_on_path() -> None:
+    """Add the ``src`` directory to ``sys.path`` when executing from the repo root."""
+
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        src_path = candidate / "src"
+        if src_path.exists():
+            src_path_str = str(src_path)
+            if src_path_str not in sys.path:
+                sys.path.insert(0, src_path_str)
+            break
+
+
+_ensure_src_on_path()
+
+from app.main import app as _fastapi_app  # noqa: E402 (requires sys.path update)
+
+
+def get_app() -> FastAPI:
+    """Return the FastAPI application instance used by the ASGI server."""
+
+    return _fastapi_app
+
+
+app = get_app()
+
+__all__ = ["app", "get_app"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = realtajo-back
+version = 0.1.0
+description = Real Tajo FC backend services
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Real Tajo FC
+
+[options]
+packages = find:
+package_dir =
+    =src
+include_package_data = True
+python_requires = >=3.10
+py_modules = server, main
+
+[options.packages.find]
+where = src

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -89,6 +89,12 @@ def create_app(
 
     app = FastAPI(title="Document Processor API", version=settings.app_version)
 
+    @app.get("/", status_code=status.HTTP_200_OK)
+    async def get_root() -> dict[str, str]:
+        """Return a simple heartbeat response for uptime monitoring."""
+
+        return {"message": "RUNNING REAL TAJO BACK"}
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -1,0 +1,17 @@
+"""HTTP route smoke tests for the FastAPI application."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_root_endpoint_returns_running_message() -> None:
+    """The root endpoint should return the expected heartbeat payload."""
+
+    client = TestClient(create_app())
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "RUNNING REAL TAJO BACK"}


### PR DESCRIPTION
## Summary
- package the project via `setup.cfg`/`pyproject.toml` and update dependencies so Azure can import the ASGI entrypoint after installation
- harden the Gunicorn entry module and expose the FastAPI app through `main.py` for default startup compatibility
- add a root heartbeat route returning "RUNNING REAL TAJO BACK" with coverage in a new smoke test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d95be0c19c8333b8c1797568a153b9