### PR TITLE
Permitir configurar el directorio de datos mediante variable de entorno

### DIFF
--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -1,7 +1,8 @@
 """Application configuration helpers."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Tuple
 
@@ -60,4 +61,10 @@ class Settings:
 def get_settings() -> Settings:
     """Provide the default application settings."""
 
-    return Settings()
+    settings = Settings()
+    upload_dir = os.getenv("UPLOAD_DIR")
+    if not upload_dir:
+        return settings
+
+    data_dir = Path(upload_dir).expanduser()
+    return replace(settings, data_dir=data_dir)


### PR DESCRIPTION
## Resumen
- permitir que la configuración lea la ruta de datos desde la variable de entorno `UPLOAD_DIR`
- mantener el resto de parámetros sin cambios cuando no se define la variable

## Pruebas
- `pytest` *(falla: tests/test_top_scorers_parser.py::test_top_scorers_parser_extracts_entries, tests/test_top_scorers_parser.py::test_top_scorers_parser_accepts_varied_row_terminators, tests/test_top_scorers_parser.py::test_top_scorers_parser_accepts_dot_decimal_row_terminator, tests/test_top_scorers_parser.py::test_top_scorers_parser_joins_split_numeric_lines)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7d2d204c83338fe5f554e7361f6a