### PR TITLE
Ensure persistent storage paths in Azure

### DIFF
--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -59,12 +59,18 @@ class Settings:
 
 
 def get_settings() -> Settings:
-    """Provide the default application settings."""
+    """Provide application settings, adapting storage for Azure deployments."""
 
     settings = Settings()
     upload_dir = os.getenv("UPLOAD_DIR")
-    if not upload_dir:
-        return settings
+    if upload_dir:
+        data_dir = Path(upload_dir).expanduser()
+        return replace(settings, data_dir=data_dir)
 
-    data_dir = Path(upload_dir).expanduser()
-    return replace(settings, data_dir=data_dir)
+    if os.getenv("WEBSITE_INSTANCE_ID"):
+        persistent_dir = Path(
+            os.getenv("APP_DATA_DIR", "/home/site/data")
+        ).expanduser()
+        return replace(settings, data_dir=persistent_dir)
+
+    return settings

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,46 @@
+"""Tests for the application settings helper."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.config.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    """Ensure environment variables are cleared between tests."""
+    monkeypatch.delenv("UPLOAD_DIR", raising=False)
+    monkeypatch.delenv("WEBSITE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("APP_DATA_DIR", raising=False)
+    yield
+
+
+def test_get_settings_uses_upload_dir_overrides(monkeypatch):
+    """When UPLOAD_DIR is defined it must take precedence over Azure defaults."""
+    monkeypatch.setenv("UPLOAD_DIR", "/tmp/custom-data")
+    monkeypatch.setenv("WEBSITE_INSTANCE_ID", "azure-instance")
+
+    settings = get_settings()
+
+    assert settings.data_dir == Path("/tmp/custom-data")
+
+
+def test_get_settings_defaults_to_azure_persistent_storage(monkeypatch):
+    """Azure environments should persist data under /home/site/data by default."""
+    monkeypatch.setenv("WEBSITE_INSTANCE_ID", "azure-instance")
+
+    settings = get_settings()
+
+    assert settings.data_dir == Path("/home/site/data")
+
+
+def test_get_settings_allows_custom_azure_storage_path(monkeypatch):
+    """A custom APP_DATA_DIR environment variable should override the Azure path."""
+    monkeypatch.setenv("WEBSITE_INSTANCE_ID", "azure-instance")
+    monkeypatch.setenv("APP_DATA_DIR", "/home/site/custom-path")
+
+    settings = get_settings()
+
+    assert settings.data_dir == Path("/home/site/custom-path")


### PR DESCRIPTION
## Summary
- update the settings factory to persist data under `/home/site/data` when running on Azure App Service and honour `APP_DATA_DIR`
- keep `UPLOAD_DIR` precedence so deployments can override storage location explicitly
- add regression tests covering Azure-specific storage selection behaviour

## Testing
- `pytest` *(fails: existing `tests/test_top_scorers_parser.py` expectations do not pass in the current main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8513402c83339342125df94b58b3