### PR TITLE
Add matchday PDF support and endpoints

### DIFF
--- a/src/app/application/process_matchday.py
+++ b/src/app/application/process_matchday.py
@@ -1,0 +1,59 @@
+"""Use cases for processing and retrieving matchday data."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.domain.models.matchday import Matchday
+from app.domain.repositories.matchday_repository import MatchdayRepository
+
+
+class MatchdayParser(Protocol):
+    """Represent a service capable of parsing matchday PDFs."""
+
+    def parse(self, document_bytes: bytes) -> Matchday:
+        """Convert the supplied PDF bytes into a ``Matchday`` model."""
+
+
+class ProcessMatchdayUseCase:
+    """Handle ingestion, parsing and persistence of matchday documents."""
+
+    def __init__(self, parser: MatchdayParser, repository: MatchdayRepository) -> None:
+        """Initialize the use case with its collaborators."""
+
+        self._parser = parser
+        self._repository = repository
+
+    def execute(self, document_bytes: bytes) -> Matchday:
+        """Parse the PDF bytes and persist the resulting matchday."""
+
+        matchday = self._parser.parse(document_bytes)
+        self._repository.save(matchday)
+        return matchday
+
+
+class RetrieveMatchdayUseCase:
+    """Retrieve a stored matchday identified by its ordinal number."""
+
+    def __init__(self, repository: MatchdayRepository) -> None:
+        """Initialize the use case with the repository dependency."""
+
+        self._repository = repository
+
+    def execute(self, number: int) -> Matchday | None:
+        """Return the requested matchday or ``None`` when absent."""
+
+        return self._repository.get(number)
+
+
+class RetrieveLatestMatchdayUseCase:
+    """Retrieve the most recently stored matchday if present."""
+
+    def __init__(self, repository: MatchdayRepository) -> None:
+        """Initialize the use case with the repository dependency."""
+
+        self._repository = repository
+
+    def execute(self) -> Matchday | None:
+        """Return the latest available matchday or ``None`` when none exist."""
+
+        return self._repository.get_last()

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -16,6 +16,7 @@ class Settings:
     schedule_filename: str = "schedule.json"
     real_tajo_calendar_filename: str = "real_tajo_calendar.json"
     top_scorers_filename: str = "top_scorers.json"
+    matchdays_directory_name: str = "matchdays"
     app_version: str = "0.1.0"
     api_version: str = "v1"
     allowed_origins: Tuple[str, ...] = ("*",)
@@ -44,6 +45,12 @@ class Settings:
         """Return the storage path for the top scorers data."""
 
         return self.data_dir / self.top_scorers_filename
+
+    @property
+    def matchdays_directory(self) -> Path:
+        """Return the directory where matchday JSON files are stored."""
+
+        return self.data_dir / self.matchdays_directory_name
 
     @property
     def api_prefix(self) -> str:

--- a/src/app/domain/models/matchday.py
+++ b/src/app/domain/models/matchday.py
@@ -2,7 +2,55 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import Any, Mapping
+
+
+_TEAM_NAME_SEPARATOR_CHARS = " -,:\u2013"
+
+
+def _normalize_team_name(name: str | None) -> str:
+    """Return a normalized version of ``name`` for case-insensitive comparisons."""
+
+    if name is None:
+        return ""
+    return " ".join(name.strip().casefold().split())
+
+
+def _extract_opponent_segment(name: str | None, team_name: str) -> str | None:
+    """Return the opponent segment when ``team_name`` is embedded in ``name``."""
+
+    if not name:
+        return None
+
+    pattern = re.compile(re.escape(team_name), flags=re.IGNORECASE)
+    match = pattern.search(name)
+    if not match:
+        return None
+
+    before = name[: match.start()].strip(_TEAM_NAME_SEPARATOR_CHARS)
+    after = name[match.end() :].strip(_TEAM_NAME_SEPARATOR_CHARS)
+
+    candidates = [segment for segment in (before, after) if _is_meaningful_opponent(segment)]
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
+
+
+def _is_meaningful_opponent(segment: str | None) -> bool:
+    """Return ``True`` when ``segment`` resembles a valid opponent name."""
+
+    if not segment:
+        return False
+
+    normalized = _normalize_team_name(segment)
+    if not normalized:
+        return False
+    if " " in normalized:
+        return True
+
+    letters = [character for character in normalized if character.isalpha()]
+    return len(letters) >= 3
 
 
 @dataclass(frozen=True)
@@ -15,16 +63,70 @@ class MatchFixture:
     away_score: int | None = None
     is_bye: bool = False
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, team_name: str | None = None) -> dict[str, Any]:
         """Return a JSON-serializable representation of the fixture."""
 
+        if team_name and not self.is_bye:
+            serialized = self._serialize_for_team(team_name)
+        else:
+            serialized = {
+                "homeTeam": self.home_team,
+                "awayTeam": self.away_team,
+            }
+
         return {
-            "homeTeam": self.home_team,
-            "awayTeam": self.away_team,
+            "homeTeam": serialized.get("homeTeam"),
+            "awayTeam": serialized.get("awayTeam"),
             "homeScore": self.home_score,
             "awayScore": self.away_score,
             "isBye": self.is_bye,
         }
+
+    def _serialize_for_team(self, team_name: str) -> dict[str, str | None]:
+        """Return team labels adjusted so ``team_name`` appears as a side."""
+
+        normalized_target = _normalize_team_name(team_name)
+        home_contains = normalized_target in _normalize_team_name(self.home_team)
+        away_contains = normalized_target in _normalize_team_name(self.away_team)
+
+        if home_contains and not away_contains:
+            opponent = _extract_opponent_segment(self.home_team, team_name)
+            return {
+                "homeTeam": opponent or self.home_team,
+                "awayTeam": team_name,
+            }
+        if away_contains and not home_contains:
+            opponent = _extract_opponent_segment(self.away_team, team_name)
+            return {
+                "homeTeam": opponent or self.home_team,
+                "awayTeam": team_name,
+            }
+        if home_contains and away_contains:
+            return {
+                "homeTeam": team_name,
+                "awayTeam": team_name,
+            }
+        return {
+            "homeTeam": self.home_team,
+            "awayTeam": self.away_team,
+        }
+
+    def involves_team(self, team_name: str) -> bool:
+        """Return ``True`` when the fixture features the provided ``team_name``."""
+
+        normalized_target = _normalize_team_name(team_name)
+        if not normalized_target:
+            return False
+
+        home_name = _normalize_team_name(self.home_team)
+        away_name = _normalize_team_name(self.away_team)
+
+        if self.is_bye:
+            return normalized_target in home_name
+
+        return normalized_target in home_name or (
+            bool(away_name) and normalized_target in away_name
+        )
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> MatchFixture:
@@ -60,12 +162,35 @@ class Matchday:
     number: int
     fixtures: list[MatchFixture] = field(default_factory=list)
 
-    def to_dict(self) -> dict[str, Any]:
-        """Return a JSON-serializable representation of the matchday."""
+    def fixtures_for_team(self, team_name: str) -> list[MatchFixture]:
+        """Return the fixtures involving ``team_name`` within the matchday."""
+
+        normalized_target = _normalize_team_name(team_name)
+        if not normalized_target:
+            return []
+
+        return [
+            fixture for fixture in self.fixtures if fixture.involves_team(team_name)
+        ]
+
+    def to_dict(self, team_name: str | None = None) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the matchday.
+
+        When ``team_name`` is provided only fixtures that include the specified
+        team are included in the serialized output.
+        """
+
+        fixtures = (
+            self.fixtures
+            if team_name is None
+            else self.fixtures_for_team(team_name)
+        )
 
         return {
             "matchdayNumber": self.number,
-            "fixtures": [fixture.to_dict() for fixture in self.fixtures],
+            "fixtures": [
+                fixture.to_dict(team_name=team_name) for fixture in fixtures
+            ],
         }
 
     @classmethod

--- a/src/app/domain/models/matchday.py
+++ b/src/app/domain/models/matchday.py
@@ -1,0 +1,87 @@
+"""Domain models describing matchday fixtures and results."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class MatchFixture:
+    """Represent a single fixture, optionally including the final score."""
+
+    home_team: str
+    away_team: str | None
+    home_score: int | None = None
+    away_score: int | None = None
+    is_bye: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the fixture."""
+
+        return {
+            "homeTeam": self.home_team,
+            "awayTeam": self.away_team,
+            "homeScore": self.home_score,
+            "awayScore": self.away_score,
+            "isBye": self.is_bye,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> MatchFixture:
+        """Create a fixture instance from its serialized representation."""
+
+        home_team = str(data.get("homeTeam", "")).strip()
+        away_team_raw = data.get("awayTeam")
+        away_team = str(away_team_raw).strip() if away_team_raw is not None else None
+
+        def _to_optional_int(value: Any) -> int | None:
+            try:
+                return int(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        home_score = _to_optional_int(data.get("homeScore"))
+        away_score = _to_optional_int(data.get("awayScore"))
+        is_bye = bool(data.get("isBye", False))
+
+        return cls(
+            home_team=home_team,
+            away_team=away_team,
+            home_score=home_score,
+            away_score=away_score,
+            is_bye=is_bye,
+        )
+
+
+@dataclass(frozen=True)
+class Matchday:
+    """Aggregate representing all fixtures associated with a matchday."""
+
+    number: int
+    fixtures: list[MatchFixture] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the matchday."""
+
+        return {
+            "matchdayNumber": self.number,
+            "fixtures": [fixture.to_dict() for fixture in self.fixtures],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Matchday:
+        """Create a matchday instance from its serialized representation."""
+
+        try:
+            number = int(data.get("matchdayNumber"))
+        except (TypeError, ValueError):
+            raise ValueError("The serialized matchday number is invalid.") from None
+
+        raw_fixtures = data.get("fixtures", [])
+        fixtures: list[MatchFixture] = []
+        if isinstance(raw_fixtures, list):
+            for entry in raw_fixtures:
+                if isinstance(entry, Mapping):
+                    fixtures.append(MatchFixture.from_dict(entry))
+
+        return cls(number=number, fixtures=fixtures)

--- a/src/app/domain/repositories/matchday_repository.py
+++ b/src/app/domain/repositories/matchday_repository.py
@@ -1,0 +1,22 @@
+"""Abstract repository contract for matchday aggregates."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from app.domain.models.matchday import Matchday
+
+
+class MatchdayRepository(ABC):
+    """Define persistence operations available for matchday entities."""
+
+    @abstractmethod
+    def save(self, matchday: Matchday) -> None:
+        """Persist the provided matchday instance."""
+
+    @abstractmethod
+    def get(self, number: int) -> Matchday | None:
+        """Return the matchday identified by ``number`` if present."""
+
+    @abstractmethod
+    def get_last(self) -> Matchday | None:
+        """Return the most recent matchday stored in the repository."""

--- a/src/app/infrastructure/parsers/matchday_pdf_parser.py
+++ b/src/app/infrastructure/parsers/matchday_pdf_parser.py
@@ -1,0 +1,239 @@
+"""PDF parser capable of extracting matchday fixtures and results."""
+from __future__ import annotations
+
+import re
+from typing import List
+
+from app.application.process_document import DocumentParser
+from app.application.process_matchday import MatchdayParser
+from app.domain.models.document import ParsedDocument
+from app.domain.models.matchday import Matchday, MatchFixture
+from app.infrastructure.parsers.pdf_document_parser import PdfDocumentParser
+
+
+_INLINE_RESULT_RE = re.compile(
+    r"^(?P<home>.+?)\s+(?P<home_score>\d+)\s*-\s*(?P<away_score>\d+)\s+(?P<away>.+?)$",
+    re.IGNORECASE,
+)
+_SCORE_ONLY_RE = re.compile(r"^(?P<home>\d+)\s*-\s*(?P<away>\d+)$")
+_DATE_RE = re.compile(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b")
+_TIME_RE = re.compile(r"\b\d{1,2}:\d{2}\b")
+_HEADER_PREFIXES = (
+    "liga",
+    "temporada",
+    "calendario",
+    "resultados",
+    "equipos",
+    "clasificacion",
+    "clasificación",
+)
+_METADATA_PREFIXES = (
+    "campo",
+    "delegacion",
+    "delegación",
+    "r.f.f.m",
+    "rffm",
+    "federacion",
+    "federación",
+)
+
+
+class MatchdayPdfParser(MatchdayParser):
+    """Parse matchday PDFs into ``Matchday`` aggregates."""
+
+    def __init__(self, document_parser: DocumentParser | None = None) -> None:
+        """Initialize the parser with the optional low-level document parser."""
+
+        self._document_parser = document_parser or PdfDocumentParser()
+
+    def parse(self, document_bytes: bytes) -> Matchday:
+        """Parse the provided PDF bytes into a ``Matchday`` domain model."""
+
+        parsed_document = self._document_parser.parse(document_bytes)
+        lines = self._flatten_lines(parsed_document)
+        matchday_number = self._extract_matchday_number(lines)
+        fixtures = self._extract_fixtures(lines)
+        if not fixtures:
+            raise ValueError("No fixtures were found in the provided matchday document.")
+        return Matchday(number=matchday_number, fixtures=fixtures)
+
+    def _flatten_lines(self, document: ParsedDocument) -> List[str]:
+        """Return a flat list of non-empty lines from the parsed document."""
+
+        lines: List[str] = []
+        for page in document.pages:
+            for line in page.content:
+                cleaned = line.strip()
+                if cleaned:
+                    lines.append(cleaned)
+        return lines
+
+    def _extract_matchday_number(self, lines: List[str]) -> int:
+        """Return the matchday number detected within the document lines."""
+
+        for line in lines:
+            match = re.search(r"jornada\s+(\d+)", line, re.IGNORECASE)
+            if match:
+                return int(match.group(1))
+        raise ValueError("The matchday number could not be determined from the document.")
+
+    def _extract_fixtures(self, lines: List[str]) -> List[MatchFixture]:
+        """Return the list of fixtures extracted from the document lines."""
+
+        fixtures: List[MatchFixture] = []
+        team_buffer: List[str] = []
+        pending_home: str | None = None
+        pending_away: str | None = None
+        pending_scores: tuple[int, int] | None = None
+
+        def finalize_fixture() -> None:
+            nonlocal pending_home, pending_away, pending_scores
+            if pending_home is None or pending_away is None:
+                return
+            fixtures.append(
+                MatchFixture(
+                    home_team=pending_home,
+                    away_team=pending_away,
+                    home_score=pending_scores[0] if pending_scores else None,
+                    away_score=pending_scores[1] if pending_scores else None,
+                    is_bye=False,
+                )
+            )
+            pending_home = None
+            pending_away = None
+            pending_scores = None
+
+        def consume_team_buffer(on_score_line: bool = False) -> None:
+            nonlocal pending_home, pending_away
+            if not team_buffer:
+                return
+            fragments = list(team_buffer)
+            team_buffer.clear()
+            if on_score_line and pending_home is None and len(fragments) >= 2:
+                home_name = self._normalise_team_name(fragments[:-1])
+                away_name = self._normalise_team_name([fragments[-1]])
+                if home_name:
+                    pending_home = home_name
+                if away_name:
+                    pending_away = away_name
+                return
+            name = self._normalise_team_name(fragments)
+            if not name:
+                return
+            if pending_home is None:
+                pending_home = name
+            elif pending_away is None:
+                pending_away = name
+            else:
+                finalize_fixture()
+                pending_home = name
+
+        for raw_line in lines:
+            line = self._normalise_whitespace(raw_line)
+            if not line:
+                continue
+
+            lower_line = line.lower()
+            if lower_line.startswith("jornada"):
+                continue
+            if any(lower_line.startswith(prefix) for prefix in _HEADER_PREFIXES):
+                continue
+
+            inline_match = _INLINE_RESULT_RE.match(line)
+            if inline_match:
+                consume_team_buffer()
+                finalize_fixture()
+                home_team = self._normalise_team_name([inline_match.group("home")])
+                away_team = self._normalise_team_name([inline_match.group("away")])
+                fixtures.append(
+                    MatchFixture(
+                        home_team=home_team,
+                        away_team=away_team,
+                        home_score=int(inline_match.group("home_score")),
+                        away_score=int(inline_match.group("away_score")),
+                        is_bye=False,
+                    )
+                )
+                pending_home = None
+                pending_away = None
+                pending_scores = None
+                continue
+
+            if lower_line.startswith("descansa"):
+                consume_team_buffer()
+                finalize_fixture()
+                rest_team = line.split(" ", 1)[1] if " " in line else ""
+                rest_team = rest_team.lstrip(": ")
+                team_name = self._normalise_team_name([rest_team])
+                if team_name:
+                    fixtures.append(
+                        MatchFixture(
+                            home_team=team_name,
+                            away_team=None,
+                            home_score=None,
+                            away_score=None,
+                            is_bye=True,
+                        )
+                    )
+                pending_home = None
+                pending_away = None
+                pending_scores = None
+                continue
+
+            score_match = _SCORE_ONLY_RE.match(line)
+            if score_match:
+                consume_team_buffer(on_score_line=True)
+                if pending_home is None and pending_away is None:
+                    continue
+                pending_scores = (int(score_match.group("home")), int(score_match.group("away")))
+                if pending_home is not None and pending_away is not None:
+                    finalize_fixture()
+                continue
+
+            if self._is_team_fragment(line):
+                team_buffer.append(line)
+                continue
+
+            consume_team_buffer()
+            finalize_fixture()
+
+        consume_team_buffer()
+        finalize_fixture()
+        return fixtures
+
+    def _normalise_whitespace(self, text: str) -> str:
+        """Collapse whitespace and exotic spaces in a line."""
+
+        cleaned = (
+            text.replace("\u00A0", " ")
+            .replace("\u2007", " ")
+            .replace("\u202F", " ")
+            .strip()
+        )
+        return re.sub(r"\s+", " ", cleaned)
+
+    def _normalise_team_name(self, fragments: List[str]) -> str:
+        """Join and clean raw text fragments describing a team name."""
+
+        text = " ".join(fragments)
+        text = _DATE_RE.sub(" ", text)
+        text = _TIME_RE.sub(" ", text)
+        if text.lower().startswith("descansa"):
+            text = text.split(" ", 1)[1] if " " in text else ""
+        text = text.replace("Campo:", " ")
+        text = text.replace("Campo", " ")
+        text = re.sub(r"\s+", " ", text)
+        return text.strip(" -,:")
+
+    def _is_team_fragment(self, line: str) -> bool:
+        """Return True when the line contains a fragment of a team name."""
+
+        lower_line = line.lower()
+        if any(lower_line.startswith(prefix) for prefix in _METADATA_PREFIXES):
+            return False
+        if _SCORE_ONLY_RE.match(line):
+            return False
+        cleaned = self._normalise_team_name([line])
+        if not cleaned:
+            return False
+        return any(char.isalpha() for char in cleaned)

--- a/src/app/infrastructure/repositories/json_matchday_repository.py
+++ b/src/app/infrastructure/repositories/json_matchday_repository.py
@@ -1,0 +1,58 @@
+"""Repository storing matchday aggregates as individual JSON files."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+from app.domain.models.matchday import Matchday
+from app.domain.repositories.matchday_repository import MatchdayRepository
+
+
+class JsonMatchdayRepository(MatchdayRepository):
+    """Persist matchday data inside a directory of JSON files."""
+
+    def __init__(self, directory_path: Path) -> None:
+        """Initialize the repository with the directory where files are stored."""
+
+        self._directory_path = directory_path
+        self._directory_path.mkdir(parents=True, exist_ok=True)
+
+    def save(self, matchday: Matchday) -> None:
+        """Serialize and persist the provided matchday aggregate."""
+
+        file_path = self._build_file_path(matchday.number)
+        with file_path.open("w", encoding="utf-8") as output_file:
+            json.dump(matchday.to_dict(), output_file, ensure_ascii=False, indent=2)
+
+    def get(self, number: int) -> Matchday | None:
+        """Load the matchday associated with ``number`` if present."""
+
+        file_path = self._build_file_path(number)
+        if not file_path.exists():
+            return None
+        with file_path.open("r", encoding="utf-8") as input_file:
+            data = json.load(input_file)
+        return Matchday.from_dict(data)
+
+    def get_last(self) -> Matchday | None:
+        """Return the matchday with the highest ordinal stored on disk."""
+
+        highest: Optional[int] = None
+        pattern = re.compile(r"matchday_(\d+)\.json$")
+        for file in self._directory_path.glob("matchday_*.json"):
+            match = pattern.match(file.name)
+            if not match:
+                continue
+            number = int(match.group(1))
+            if highest is None or number > highest:
+                highest = number
+        if highest is None:
+            return None
+        return self.get(highest)
+
+    def _build_file_path(self, number: int) -> Path:
+        """Return the path where the given matchday number should be stored."""
+
+        return self._directory_path / f"matchday_{number}.json"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -18,6 +18,12 @@ from app.application.process_classification import (
     ProcessClassificationUseCase,
     RetrieveClassificationUseCase,
 )
+from app.application.process_matchday import (
+    MatchdayParser,
+    ProcessMatchdayUseCase,
+    RetrieveLatestMatchdayUseCase,
+    RetrieveMatchdayUseCase,
+)
 from app.application.process_document import (
     DocumentParser,
     ProcessDocumentUseCase,
@@ -36,12 +42,14 @@ from app.application.process_top_scorers import (
 from app.config.settings import get_settings
 from app.domain.repositories.classification_repository import ClassificationRepository
 from app.domain.repositories.document_repository import DocumentRepository
+from app.domain.repositories.matchday_repository import MatchdayRepository
 from app.domain.repositories.real_tajo_calendar_repository import (
     RealTajoCalendarRepository,
 )
 from app.domain.repositories.top_scorer_repository import TopScorersRepository
 from app.domain.services.classification_extractor import ClassificationExtractorService
 from app.infrastructure.parsers.pdf_document_parser import PdfDocumentParser
+from app.infrastructure.parsers.matchday_pdf_parser import MatchdayPdfParser
 from app.infrastructure.repositories.json_classification_repository import (
     JsonClassificationRepository,
 )
@@ -49,6 +57,9 @@ from app.infrastructure.parsers.real_tajo_calendar_parser import (
     RealTajoCalendarPdfParser,
 )
 from app.infrastructure.repositories.json_file_repository import JsonFileRepository
+from app.infrastructure.repositories.json_matchday_repository import (
+    JsonMatchdayRepository,
+)
 from app.infrastructure.repositories.json_real_tajo_calendar_repository import (
     JsonRealTajoCalendarRepository,
 )
@@ -66,6 +77,8 @@ def create_app(
     real_tajo_repo: RealTajoCalendarRepository | None = None,
     top_scorers_parser: TopScorersParser | None = None,
     top_scorers_repo: TopScorersRepository | None = None,
+    matchday_parser: MatchdayParser | None = None,
+    matchday_repo: MatchdayRepository | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application instance."""
 
@@ -85,6 +98,11 @@ def create_app(
         top_scorers_repo
         if top_scorers_repo is not None
         else JsonTopScorersRepository(settings.top_scorers_path)
+    )
+    matchday_repository = (
+        matchday_repo
+        if matchday_repo is not None
+        else JsonMatchdayRepository(settings.matchdays_directory)
     )
 
     classification_extractor = ClassificationExtractorService()
@@ -110,6 +128,14 @@ def create_app(
         scorers_repository,
     )
     top_scorers_retriever = RetrieveTopScorersUseCase(scorers_repository)
+
+    matchday_parser_service = matchday_parser or MatchdayPdfParser(pdf_parser)
+    matchday_processor = ProcessMatchdayUseCase(
+        matchday_parser_service,
+        matchday_repository,
+    )
+    matchday_retriever = RetrieveMatchdayUseCase(matchday_repository)
+    latest_matchday_retriever = RetrieveLatestMatchdayUseCase(matchday_repository)
 
     app = FastAPI(title="Document Processor API", version=settings.app_version)
 
@@ -234,6 +260,39 @@ def create_app(
                 detail="No processed top scorers document available.",
             )
         return table.to_dict()
+
+    @api_router.put("/matchdays", status_code=status.HTTP_200_OK)
+    async def upload_matchday(response: Response, file: UploadFile = File(...)) -> dict:
+        """Parse and persist the uploaded matchday PDF, returning its JSON form."""
+
+        pdf_bytes = await _read_pdf_bytes(file, settings.max_upload_size_bytes)
+        matchday = _execute_processor(matchday_processor.execute, pdf_bytes)
+        response.headers["Location"] = f"{settings.api_prefix}/matchdays/{matchday.number}"
+        return matchday.to_dict()
+
+    @api_router.get("/matchdays/last", status_code=status.HTTP_200_OK)
+    async def get_latest_matchday() -> dict:
+        """Retrieve the most recently processed matchday as JSON."""
+
+        matchday = latest_matchday_retriever.execute()
+        if matchday is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No processed matchdays available.",
+            )
+        return matchday.to_dict()
+
+    @api_router.get("/matchdays/{number}", status_code=status.HTTP_200_OK)
+    async def get_matchday(number: int) -> dict:
+        """Retrieve the stored matchday identified by ``number`` as JSON."""
+
+        matchday = matchday_retriever.execute(number)
+        if matchday is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No processed matchday found for the requested number.",
+            )
+        return matchday.to_dict()
 
     app.include_router(api_router)
     return app

--- a/src/realtajo_back.egg-info/SOURCES.txt
+++ b/src/realtajo_back.egg-info/SOURCES.txt
@@ -40,4 +40,5 @@ tests/test_classification_extractor.py
 tests/test_json_classification_repository.py
 tests/test_json_top_scorers_repository.py
 tests/test_real_tajo_calendar_parser.py
+tests/test_settings.py
 tests/test_top_scorers_parser.py

--- a/tests/test_json_matchday_repository.py
+++ b/tests/test_json_matchday_repository.py
@@ -1,0 +1,47 @@
+"""Tests for the JSON-backed matchday repository."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.domain.models.matchday import Matchday, MatchFixture
+from app.infrastructure.repositories.json_matchday_repository import JsonMatchdayRepository
+
+
+def test_repository_persists_and_loads_matchday(tmp_path: Path) -> None:
+    """Saving a matchday should persist it as JSON and allow reloading."""
+
+    repository = JsonMatchdayRepository(tmp_path)
+    matchday = Matchday(
+        number=3,
+        fixtures=[
+            MatchFixture(home_team="Team A", away_team="Team B", home_score=1, away_score=0),
+            MatchFixture(home_team="Resting", away_team=None, is_bye=True),
+        ],
+    )
+
+    repository.save(matchday)
+
+    loaded = repository.get(3)
+    assert loaded == matchday
+
+
+def test_repository_returns_last_matchday(tmp_path: Path) -> None:
+    """The repository should return the matchday with the highest number."""
+
+    repository = JsonMatchdayRepository(tmp_path)
+    repository.save(
+        Matchday(
+            number=2,
+            fixtures=[MatchFixture(home_team="Home", away_team="Away")],
+        )
+    )
+    repository.save(
+        Matchday(
+            number=5,
+            fixtures=[MatchFixture(home_team="Later", away_team="Opponent", home_score=2, away_score=2)],
+        )
+    )
+
+    latest = repository.get_last()
+    assert latest is not None
+    assert latest.number == 5

--- a/tests/test_matchday_endpoints.py
+++ b/tests/test_matchday_endpoints.py
@@ -1,0 +1,97 @@
+"""Integration tests for matchday endpoints."""
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi.testclient import TestClient
+
+from app.application.process_matchday import MatchdayParser
+from app.domain.models.matchday import Matchday, MatchFixture
+from app.domain.repositories.matchday_repository import MatchdayRepository
+from app.main import create_app
+
+
+class _StubMatchdayParser(MatchdayParser):
+    """Stub parser returning a predefined matchday."""
+
+    def __init__(self, matchday: Matchday) -> None:
+        self._matchday = matchday
+        self.received_bytes: bytes | None = None
+
+    def parse(self, document_bytes: bytes) -> Matchday:  # noqa: D401 - protocol compliance
+        """Return the stored matchday while remembering the input bytes."""
+
+        self.received_bytes = document_bytes
+        return self._matchday
+
+
+class _InMemoryMatchdayRepository(MatchdayRepository):
+    """In-memory repository used to test the HTTP layer."""
+
+    def __init__(self) -> None:
+        self._data: Dict[int, Matchday] = {}
+
+    def save(self, matchday: Matchday) -> None:  # noqa: D401 - protocol compliance
+        """Store the given matchday in memory."""
+
+        self._data[matchday.number] = matchday
+
+    def get(self, number: int) -> Matchday | None:  # noqa: D401 - protocol compliance
+        """Return the stored matchday for ``number`` if present."""
+
+        return self._data.get(number)
+
+    def get_last(self) -> Matchday | None:  # noqa: D401 - protocol compliance
+        """Return the matchday with the highest key in memory."""
+
+        if not self._data:
+            return None
+        return self._data[max(self._data)]
+
+
+def test_upload_and_retrieve_matchday_endpoints() -> None:
+    """Uploading a matchday should persist it and allow retrieval."""
+
+    matchday = Matchday(
+        number=7,
+        fixtures=[
+            MatchFixture(home_team="Team A", away_team="Team B", home_score=2, away_score=1),
+            MatchFixture(home_team="Rest", away_team=None, is_bye=True),
+        ],
+    )
+    parser = _StubMatchdayParser(matchday)
+    repository = _InMemoryMatchdayRepository()
+    app = create_app(matchday_parser=parser, matchday_repo=repository)
+    client = TestClient(app)
+
+    response = client.put(
+        "/api/v1/matchdays",
+        files={"file": ("matchday.pdf", b"pdf-bytes", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == matchday.to_dict()
+    assert response.headers["Location"] == "/api/v1/matchdays/7"
+    assert repository.get(7) == matchday
+    assert parser.received_bytes == b"pdf-bytes"
+
+    retrieved = client.get("/api/v1/matchdays/7")
+    assert retrieved.status_code == 200
+    assert retrieved.json() == matchday.to_dict()
+
+    latest = client.get("/api/v1/matchdays/last")
+    assert latest.status_code == 200
+    assert latest.json() == matchday.to_dict()
+
+
+def test_matchday_endpoints_return_not_found_when_empty() -> None:
+    """Retrieving absent matchdays should result in ``404`` responses."""
+
+    app = create_app(matchday_parser=_StubMatchdayParser(Matchday(1, [])), matchday_repo=_InMemoryMatchdayRepository())
+    client = TestClient(app)
+
+    response_number = client.get("/api/v1/matchdays/99")
+    assert response_number.status_code == 404
+
+    response_last = client.get("/api/v1/matchdays/last")
+    assert response_last.status_code == 404

--- a/tests/test_matchday_endpoints.py
+++ b/tests/test_matchday_endpoints.py
@@ -55,7 +55,12 @@ def test_upload_and_retrieve_matchday_endpoints() -> None:
     matchday = Matchday(
         number=7,
         fixtures=[
-            MatchFixture(home_team="Team A", away_team="Team B", home_score=2, away_score=1),
+            MatchFixture(
+                home_team="Team A",
+                away_team="REAL TAJO",
+                home_score=2,
+                away_score=1,
+            ),
             MatchFixture(home_team="Rest", away_team=None, is_bye=True),
         ],
     )
@@ -70,18 +75,19 @@ def test_upload_and_retrieve_matchday_endpoints() -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == matchday.to_dict()
+    expected_payload = matchday.to_dict(team_name="REAL TAJO")
+    assert response.json() == expected_payload
     assert response.headers["Location"] == "/api/v1/matchdays/7"
     assert repository.get(7) == matchday
     assert parser.received_bytes == b"pdf-bytes"
 
     retrieved = client.get("/api/v1/matchdays/7")
     assert retrieved.status_code == 200
-    assert retrieved.json() == matchday.to_dict()
+    assert retrieved.json() == expected_payload
 
     latest = client.get("/api/v1/matchdays/last")
     assert latest.status_code == 200
-    assert latest.json() == matchday.to_dict()
+    assert latest.json() == expected_payload
 
 
 def test_matchday_endpoints_return_not_found_when_empty() -> None:

--- a/tests/test_matchday_model.py
+++ b/tests/test_matchday_model.py
@@ -1,0 +1,88 @@
+"""Tests for the matchday domain model."""
+from __future__ import annotations
+
+from app.domain.models.matchday import Matchday, MatchFixture
+
+
+def test_fixtures_for_team_filters_home_and_away_matches() -> None:
+    """Only fixtures containing the requested team should be returned."""
+
+    matchday = Matchday(
+        number=1,
+        fixtures=[
+            MatchFixture(home_team="REAL SPORT", away_team="REAL TAJO"),
+            MatchFixture(home_team="Another Club", away_team="Different"),
+            MatchFixture(home_team="Club", away_team="Club Real Tajo"),
+        ],
+    )
+
+    fixtures = matchday.fixtures_for_team("REAL TAJO")
+
+    assert len(fixtures) == 2
+    assert fixtures[0].away_team == "REAL TAJO"
+    assert fixtures[1].away_team == "Club Real Tajo"
+
+
+def test_fixtures_for_team_includes_bye_information() -> None:
+    """Bye rounds for Real Tajo should be included in the filtered fixtures."""
+
+    matchday = Matchday(
+        number=2,
+        fixtures=[
+            MatchFixture(home_team="Real Tajo", away_team=None, is_bye=True),
+            MatchFixture(home_team="Opponent", away_team="Other"),
+        ],
+    )
+
+    fixtures = matchday.fixtures_for_team("REAL TAJO")
+
+    assert len(fixtures) == 1
+    assert fixtures[0].is_bye
+
+
+def test_to_dict_normalizes_combined_names_for_real_tajo() -> None:
+    """Serializing should split concatenated Real Tajo fixtures into two teams."""
+
+    matchday = Matchday(
+        number=3,
+        fixtures=[
+            MatchFixture(
+                home_team="REAL SPORT REAL TAJO",
+                away_team="RACING ARANJUEZ ALBIRROJA",
+            )
+        ],
+    )
+
+    payload = matchday.to_dict(team_name="REAL TAJO")
+
+    assert payload == {
+        "matchdayNumber": 3,
+        "fixtures": [
+            {
+                "homeTeam": "REAL SPORT",
+                "awayTeam": "REAL TAJO",
+                "homeScore": None,
+                "awayScore": None,
+                "isBye": False,
+            }
+        ],
+    }
+
+
+def test_to_dict_preserves_real_tajo_variants_without_splitting() -> None:
+    """Team variants such as Real Tajo CF should remain untouched when serializing."""
+
+    matchday = Matchday(
+        number=4,
+        fixtures=[
+            MatchFixture(
+                home_team="RACING ARANJUEZ",
+                away_team="REAL TAJO C.F.",
+            )
+        ],
+    )
+
+    payload = matchday.to_dict(team_name="REAL TAJO")
+
+    assert payload["fixtures"][0]["homeTeam"] == "RACING ARANJUEZ"
+    assert payload["fixtures"][0]["awayTeam"] == "REAL TAJO"

--- a/tests/test_matchday_pdf_parser.py
+++ b/tests/test_matchday_pdf_parser.py
@@ -1,0 +1,132 @@
+"""Tests for the matchday PDF parser heuristics."""
+from __future__ import annotations
+
+from app.domain.models.document import DocumentPage, ParsedDocument
+from app.infrastructure.parsers.matchday_pdf_parser import MatchdayPdfParser
+
+
+class _StubDocumentParser:
+    """Stub document parser returning a prepared ``ParsedDocument``."""
+
+    def __init__(self, document: ParsedDocument) -> None:
+        self._document = document
+
+    def parse(self, document_bytes: bytes) -> ParsedDocument:  # noqa: D401 - protocol compliance
+        """Return the stored document regardless of the provided bytes."""
+
+        return self._document
+
+
+def test_parser_extracts_matchday_without_scores() -> None:
+    """Parser should extract fixtures even when no scores are present."""
+
+    page = DocumentPage(
+        number=1,
+        content=[
+            "LIGA AFICIONADOS F-11, 3ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Jornada 1",
+            "Resultados",
+            "Descansa AMERICA",
+            "REAL SPORT 11-10-2025",
+            "15:30",
+            "REAL TAJO",
+            "Campo: ENRIQUE MORENO - B - Hierba Artificial",
+            "RACING ARANJUEZ 11-10-2025",
+            "20:00",
+            "ALBIRROJA",
+            "Campo: ENRIQUE MORENO - B - Hierba Artificial",
+            "LA VESPA TAPAS-CLUB",
+            "ATLETICO DE ARANJUEZ 12-10-2025",
+            "09:00",
+            "AMG-ASESORIA JURIDICAEXCAVACIONES",
+            "TAJO",
+            "Campo: ENRIQUE MORENO - B - Hierba Artificial",
+            "IRT ARANJUEZ 12-10-2025",
+            "09:00",
+            "CELTIC C.F.",
+            "Campo: ENRIQUE MORENO - F - Hierba Artificial",
+        ],
+    )
+    document = ParsedDocument(pages=[page])
+    parser = MatchdayPdfParser(document_parser=_StubDocumentParser(document))
+
+    matchday = parser.parse(b"dummy")
+
+    assert matchday.number == 1
+    assert [fixture.is_bye for fixture in matchday.fixtures] == [True, False, False, False, False]
+    assert matchday.fixtures[0].home_team == "AMERICA"
+    assert matchday.fixtures[1].home_team == "REAL SPORT"
+    assert matchday.fixtures[1].away_team == "REAL TAJO"
+    assert matchday.fixtures[2].home_team == "RACING ARANJUEZ"
+    assert matchday.fixtures[2].away_team == "ALBIRROJA"
+    assert matchday.fixtures[3].home_team == "LA VESPA TAPAS-CLUB ATLETICO DE ARANJUEZ"
+    assert matchday.fixtures[3].away_team == "AMG-ASESORIA JURIDICAEXCAVACIONES TAJO"
+    assert matchday.fixtures[4].home_team == "IRT ARANJUEZ"
+    assert matchday.fixtures[4].away_team == "CELTIC C.F."
+    assert all(fixture.home_score is None for fixture in matchday.fixtures if not fixture.is_bye)
+
+
+def test_parser_extracts_scores_and_results() -> None:
+    """Parser should extract scores when present in the PDF content."""
+
+    page = DocumentPage(
+        number=1,
+        content=[
+            "LIGA AFICIONADOS F-11, 2ª AFICIONADOS F-11 Temporada 2025-2026",
+            "Jornada 3",
+            "Resultados",
+            "C.D. VETERANOS PANTOJA 0 - 1 RAIMON",
+            "Descansa UNION CAFETERA",
+            "NEW COTTON MEKASO MCS",
+            "05-10-2025",
+            "10:30",
+            "CAFETERIA LA TACITA",
+            "Campo: ENRIQUE MORENO - B - Hierba Artificial",
+            "SHOTS FC",
+            "3 - 2",
+            "05-10-2025",
+            "10:30",
+            "FC. RAYO ARANJUEZ",
+            "Campo: ENRIQUE MORENO - F - Hierba Artificial",
+            "TABERNA CASARES / MISTER",
+            "PIXEL",
+            "0 - 0",
+            "Campo: ENRIQUE MORENO - C - Hierba Artificial",
+            "GOLDEN F.C.",
+            "05-10-2025",
+            "12:00",
+            "ATLETICO PERU",
+            "Campo: ENRIQUE MORENO - D - Hierba Artificial",
+            "CHESTERFIELD UNITED",
+            "ALPHA TEAM",
+            "0 - 0",
+            "Campo: ENRIQUE MORENO - E - Hierba Artificial",
+        ],
+    )
+    document = ParsedDocument(pages=[page])
+    parser = MatchdayPdfParser(document_parser=_StubDocumentParser(document))
+
+    matchday = parser.parse(b"dummy")
+
+    assert matchday.number == 3
+    fixtures = [fixture for fixture in matchday.fixtures if not fixture.is_bye]
+    assert fixtures[0].home_team == "C.D. VETERANOS PANTOJA"
+    assert fixtures[0].away_team == "RAIMON"
+    assert fixtures[0].home_score == 0
+    assert fixtures[0].away_score == 1
+    assert matchday.fixtures[1].is_bye
+    assert fixtures[1].home_team == "NEW COTTON MEKASO MCS"
+    assert fixtures[1].away_team == "CAFETERIA LA TACITA"
+    assert fixtures[1].home_score is None and fixtures[1].away_score is None
+    assert fixtures[2].home_team == "SHOTS FC"
+    assert fixtures[2].away_team == "FC. RAYO ARANJUEZ"
+    assert fixtures[2].home_score == 3 and fixtures[2].away_score == 2
+    assert fixtures[3].home_team == "TABERNA CASARES / MISTER"
+    assert fixtures[3].away_team == "PIXEL"
+    assert fixtures[3].home_score == 0 and fixtures[3].away_score == 0
+    assert fixtures[4].home_team == "GOLDEN F.C."
+    assert fixtures[4].away_team == "ATLETICO PERU"
+    assert fixtures[4].home_score is None and fixtures[4].away_score is None
+    assert fixtures[5].home_team == "CHESTERFIELD UNITED"
+    assert fixtures[5].away_team == "ALPHA TEAM"
+    assert fixtures[5].home_score == 0 and fixtures[5].away_score == 0


### PR DESCRIPTION
## Summary
- add domain, application, and infrastructure layers to parse matchday PDFs and persist them as JSON
- expose FastAPI endpoints to upload matchday PDFs, fetch individual matchdays, and retrieve the latest matchday
- cover the new functionality with parser, repository, and endpoint tests

## Testing
- pytest tests/test_matchday_endpoints.py tests/test_matchday_pdf_parser.py tests/test_json_matchday_repository.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e25806e1ec83339373d13716818519