### PR TITLE
Filter matchday endpoints to Real Tajo fixtures

### DIFF
--- a/src/app/domain/models/matchday.py
+++ b/src/app/domain/models/matchday.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import Any, Mapping
+
+
+_TEAM_NAME_SEPARATOR_CHARS = " -,:\u2013"
 
 
 def _normalize_team_name(name: str | None) -> str:
@@ -11,6 +15,42 @@ def _normalize_team_name(name: str | None) -> str:
     if name is None:
         return ""
     return " ".join(name.strip().casefold().split())
+
+
+def _extract_opponent_segment(name: str | None, team_name: str) -> str | None:
+    """Return the opponent segment when ``team_name`` is embedded in ``name``."""
+
+    if not name:
+        return None
+
+    pattern = re.compile(re.escape(team_name), flags=re.IGNORECASE)
+    match = pattern.search(name)
+    if not match:
+        return None
+
+    before = name[: match.start()].strip(_TEAM_NAME_SEPARATOR_CHARS)
+    after = name[match.end() :].strip(_TEAM_NAME_SEPARATOR_CHARS)
+
+    candidates = [segment for segment in (before, after) if _is_meaningful_opponent(segment)]
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
+
+
+def _is_meaningful_opponent(segment: str | None) -> bool:
+    """Return ``True`` when ``segment`` resembles a valid opponent name."""
+
+    if not segment:
+        return False
+
+    normalized = _normalize_team_name(segment)
+    if not normalized:
+        return False
+    if " " in normalized:
+        return True
+
+    letters = [character for character in normalized if character.isalpha()]
+    return len(letters) >= 3
 
 
 @dataclass(frozen=True)
@@ -23,15 +63,52 @@ class MatchFixture:
     away_score: int | None = None
     is_bye: bool = False
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, team_name: str | None = None) -> dict[str, Any]:
         """Return a JSON-serializable representation of the fixture."""
 
+        if team_name and not self.is_bye:
+            serialized = self._serialize_for_team(team_name)
+        else:
+            serialized = {
+                "homeTeam": self.home_team,
+                "awayTeam": self.away_team,
+            }
+
         return {
-            "homeTeam": self.home_team,
-            "awayTeam": self.away_team,
+            "homeTeam": serialized.get("homeTeam"),
+            "awayTeam": serialized.get("awayTeam"),
             "homeScore": self.home_score,
             "awayScore": self.away_score,
             "isBye": self.is_bye,
+        }
+
+    def _serialize_for_team(self, team_name: str) -> dict[str, str | None]:
+        """Return team labels adjusted so ``team_name`` appears as a side."""
+
+        normalized_target = _normalize_team_name(team_name)
+        home_contains = normalized_target in _normalize_team_name(self.home_team)
+        away_contains = normalized_target in _normalize_team_name(self.away_team)
+
+        if home_contains and not away_contains:
+            opponent = _extract_opponent_segment(self.home_team, team_name)
+            return {
+                "homeTeam": opponent or self.home_team,
+                "awayTeam": team_name,
+            }
+        if away_contains and not home_contains:
+            opponent = _extract_opponent_segment(self.away_team, team_name)
+            return {
+                "homeTeam": opponent or self.home_team,
+                "awayTeam": team_name,
+            }
+        if home_contains and away_contains:
+            return {
+                "homeTeam": team_name,
+                "awayTeam": team_name,
+            }
+        return {
+            "homeTeam": self.home_team,
+            "awayTeam": self.away_team,
         }
 
     def involves_team(self, team_name: str) -> bool:
@@ -111,7 +188,9 @@ class Matchday:
 
         return {
             "matchdayNumber": self.number,
-            "fixtures": [fixture.to_dict() for fixture in fixtures],
+            "fixtures": [
+                fixture.to_dict(team_name=team_name) for fixture in fixtures
+            ],
         }
 
     @classmethod

--- a/tests/test_matchday_endpoints.py
+++ b/tests/test_matchday_endpoints.py
@@ -55,7 +55,12 @@ def test_upload_and_retrieve_matchday_endpoints() -> None:
     matchday = Matchday(
         number=7,
         fixtures=[
-            MatchFixture(home_team="Team A", away_team="Team B", home_score=2, away_score=1),
+            MatchFixture(
+                home_team="Team A",
+                away_team="REAL TAJO",
+                home_score=2,
+                away_score=1,
+            ),
             MatchFixture(home_team="Rest", away_team=None, is_bye=True),
         ],
     )
@@ -70,18 +75,19 @@ def test_upload_and_retrieve_matchday_endpoints() -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == matchday.to_dict()
+    expected_payload = matchday.to_dict(team_name="REAL TAJO")
+    assert response.json() == expected_payload
     assert response.headers["Location"] == "/api/v1/matchdays/7"
     assert repository.get(7) == matchday
     assert parser.received_bytes == b"pdf-bytes"
 
     retrieved = client.get("/api/v1/matchdays/7")
     assert retrieved.status_code == 200
-    assert retrieved.json() == matchday.to_dict()
+    assert retrieved.json() == expected_payload
 
     latest = client.get("/api/v1/matchdays/last")
     assert latest.status_code == 200
-    assert latest.json() == matchday.to_dict()
+    assert latest.json() == expected_payload
 
 
 def test_matchday_endpoints_return_not_found_when_empty() -> None:

--- a/tests/test_matchday_model.py
+++ b/tests/test_matchday_model.py
@@ -1,0 +1,40 @@
+"""Tests for the matchday domain model."""
+from __future__ import annotations
+
+from app.domain.models.matchday import Matchday, MatchFixture
+
+
+def test_fixtures_for_team_filters_home_and_away_matches() -> None:
+    """Only fixtures containing the requested team should be returned."""
+
+    matchday = Matchday(
+        number=1,
+        fixtures=[
+            MatchFixture(home_team="REAL SPORT", away_team="REAL TAJO"),
+            MatchFixture(home_team="Another Club", away_team="Different"),
+            MatchFixture(home_team="Club", away_team="Club Real Tajo"),
+        ],
+    )
+
+    fixtures = matchday.fixtures_for_team("REAL TAJO")
+
+    assert len(fixtures) == 2
+    assert fixtures[0].away_team == "REAL TAJO"
+    assert fixtures[1].away_team == "Club Real Tajo"
+
+
+def test_fixtures_for_team_includes_bye_information() -> None:
+    """Bye rounds for Real Tajo should be included in the filtered fixtures."""
+
+    matchday = Matchday(
+        number=2,
+        fixtures=[
+            MatchFixture(home_team="Real Tajo", away_team=None, is_bye=True),
+            MatchFixture(home_team="Opponent", away_team="Other"),
+        ],
+    )
+
+    fixtures = matchday.fixtures_for_team("REAL TAJO")
+
+    assert len(fixtures) == 1
+    assert fixtures[0].is_bye

--- a/tests/test_matchday_model.py
+++ b/tests/test_matchday_model.py
@@ -38,3 +38,51 @@ def test_fixtures_for_team_includes_bye_information() -> None:
 
     assert len(fixtures) == 1
     assert fixtures[0].is_bye
+
+
+def test_to_dict_normalizes_combined_names_for_real_tajo() -> None:
+    """Serializing should split concatenated Real Tajo fixtures into two teams."""
+
+    matchday = Matchday(
+        number=3,
+        fixtures=[
+            MatchFixture(
+                home_team="REAL SPORT REAL TAJO",
+                away_team="RACING ARANJUEZ ALBIRROJA",
+            )
+        ],
+    )
+
+    payload = matchday.to_dict(team_name="REAL TAJO")
+
+    assert payload == {
+        "matchdayNumber": 3,
+        "fixtures": [
+            {
+                "homeTeam": "REAL SPORT",
+                "awayTeam": "REAL TAJO",
+                "homeScore": None,
+                "awayScore": None,
+                "isBye": False,
+            }
+        ],
+    }
+
+
+def test_to_dict_preserves_real_tajo_variants_without_splitting() -> None:
+    """Team variants such as Real Tajo CF should remain untouched when serializing."""
+
+    matchday = Matchday(
+        number=4,
+        fixtures=[
+            MatchFixture(
+                home_team="RACING ARANJUEZ",
+                away_team="REAL TAJO C.F.",
+            )
+        ],
+    )
+
+    payload = matchday.to_dict(team_name="REAL TAJO")
+
+    assert payload["fixtures"][0]["homeTeam"] == "RACING ARANJUEZ"
+    assert payload["fixtures"][0]["awayTeam"] == "REAL TAJO"


### PR DESCRIPTION
## Summary
- add domain helpers to detect fixtures involving a specific team and filter matchdays accordingly
- return only Real Tajo fixtures from matchday endpoints while keeping persisted data intact
- extend integration coverage and add unit tests for the filtering behaviour

## Testing
- `pytest` *(fails: known TopScorersPdfParser expectations about title/ratios remain unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68e25c99cd1c83339420b4047041b39c